### PR TITLE
Version 2.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish package to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.x
+
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install
+
+      - name: Test with pytest
+        run: poetry run python3 -m pytest tests/
+
+      - name: Publish package
+        run: |
+          poetry build
+          poetry publish -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,17 +1,21 @@
-name: Python package
+name: Run tests
 
-on: [push]
+on:
+  push:
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+      - ".github/workflows/**.yml"
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 3
       matrix:
         python-version: [3.6, 3.7, 3.8]
-
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout repository
+        uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
@@ -21,5 +25,4 @@ jobs:
           pip install poetry
           poetry install
       - name: Test with pytest
-        run: |
-          poetry run python3 -m pytest tests/
+        run: poetry run python3 -m pytest tests/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,30 @@ pip install lethargy
 
 ## Usage
 
-Here's an excerpt from script I wrote for work, without lethargy.
+```python
+import lethargy
+
+n_bytes = lethargy.take('bytes', 1, int) or 8
+
+# After removing --bytes and its value from argv, the dir should be first.
+directory = lethargy.argv[1]
+
+...
+```
+
+That's an excerpt from a script I wrote for my job.
+
+<details>
+<summary>Show this example with manual extraction</summary>
+<br>
+
+Done manually, there's a lot of detail that's not relevant to the actual script.
+* What happens if the option isn't present?
+* What happens if it is but has no value?
+* What about if that value isn't an int?
+* How do you communicate what went wrong?
+
+All these implementation details increase the maintenance and complexity. This shouldn't be handled by _you_.
 
 ```python
 import sys
@@ -45,20 +68,12 @@ directory = sys.argv[1]
 ...
 ```
 
-Here's the same excerpt but using lethargy. It takes 1 line to do what 9 did manually, with pretty good error messages.
+</details>
 
-```python
-import lethargy
-
-# After removing --bytes and its value from argv, the dir should be first.
-n_bytes = lethargy.take('bytes', 1, int) or 8
-directory = lethargy.argv[1]
-
-...
-```
+<br>
 
 <details>
-<summary>Show this example using Click</summary>
+<summary>Show this example using Click instead</summary>
 <br>
 
 Click _forces you into a specific style_ that just isn't great for some scripts. It requires a lot of boilerplate, and while you get a lot for free from that, it's also more to maintain and detracts from the script's _actual_ logic.
@@ -176,7 +191,7 @@ If there are fewer values for the option than the number given, `lethargy.ArgsEr
 $ python example.py --output
 Traceback (most recent call last):
   [...]
-lethargy.errors.ArgsError: expected 1 argument for '-o|--output <value>', found 0
+lethargy.errors.ArgsError: expected 1 argument for '-o|--output <value>', found none
 ```
 
 <hr>
@@ -270,6 +285,19 @@ print(f'it has been {delta.days} days since {date}')
 ```console
 $ python example.py --date-ymd 1999 10 9
 it has been 7500 days since 1999-10-09 00:00:00
+```
+
+<br>
+
+**Give clear error messages.** Lucky for you, lethargy's errors are great.
+
+```python
+try:
+    n_bytes = lethargy.take('bytes', 1, int) or 8
+    start, end = lethargy.take(['r', 'range'], 2, int) or 0, 10
+    files = lethargy.argv[1:]
+except (lethargy.OptionError, ValueError) as err:
+    lethargy.fail(err)
 ```
 
 <br>

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Lethargy is **not** a CLI framework. If you're building a complete CLI, you're b
 [Click]: https://click.palletsprojects.com/en/7.x/
 [Getting Started]: #getting-started
 
+## Installation
+
+You can use pip to install lethargy. It's tiny and only depends on the standard library.
+
+```console
+pip install lethargy
+```
+
 ## Usage
 
 ```python
@@ -31,14 +39,6 @@ except IndexError:
     lethargy.fail("Missing required directory")
 
 ...
-```
-
-## Installation
-
-You can use pip to install lethargy. It's tiny and only depends on the standard library.
-
-```console
-pip install lethargy
 ```
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ Lethargy is **not** a CLI framework. If you're building a complete CLI, you're b
 [Click]: https://click.palletsprojects.com/en/7.x/
 [Getting Started]: #getting-started
 
+## Usage
+
+```python
+import lethargy
+
+# We'll take the option '--bytes <int>'.
+# The context manager provides some nice default error handling.
+with lethargy.show_errors():
+    n_bytes = lethargy.take_opt('bytes', 1, int) or 8
+
+# ``take_opt`` removes the option and its value from ``argv``.
+# The directory is a mandatory argument, so we'll take it directly by its index.
+try:
+    directory = lethargy.argv[1]
+except IndexError:
+    lethargy.fail("Missing required directory")
+
+...
+```
+
 ## Installation
 
 You can use pip to install lethargy. It's tiny and only depends on the standard library.
@@ -21,31 +41,17 @@ You can use pip to install lethargy. It's tiny and only depends on the standard 
 pip install lethargy
 ```
 
-## Usage
-
-```python
-import lethargy
-
-# --bytes <int>
-n_bytes = lethargy.take('bytes', 1, int) or 8
-
-# After removing --bytes and its value from argv, the dir should be first.
-directory = lethargy.argv[1]
-
-...
-```
-
 ## Getting Started
 
 For simplicity, all examples assume you've got `import lethargy` at the top.
 
-<br>
+###### FLAGS
 
 **Options can be flags.** `True` if present, `False` if not.
 
 ```python
 # --debug
-debug = lethargy.take('debug')
+debug = lethargy.take_opt('debug')
 
 print(debug)
 ```
@@ -59,11 +65,13 @@ False
 
 <br>
 
+###### NAMES
+
 **Options can have more than one name.** Instead of a string, use a list or tuple. Names are case-sensitive.
 
 ```python
 # -v|--verbose
-verbose = lethargy.take(['v', 'verbose'])
+verbose = lethargy.take_opt(['v', 'verbose'])
 
 print(verbose)
 ```
@@ -85,7 +93,7 @@ If you provide an explicit name (starting with a non-alphanumeric character, suc
 
 ```python
 # -Enable
-enabled = lethargy.take('-Enable')
+enabled = lethargy.take_opt('-Enable')
 print(enabled)
 ```
 
@@ -106,11 +114,13 @@ False
 <hr>
 </details>
 
+###### ARGUMENTS
+
 **Options can take arguments, too.** They can take any amount.
 
 ```python
 # -o|--output <value>
-output = lethargy.take(['o', 'output'], 1)
+output = lethargy.take_opt(['o', 'output'], 1)
 
 print(output)
 ```
@@ -126,7 +136,7 @@ None
 <summary align="right">Learn more about arguments</summary>
 <br>
 
-If there are fewer values for the option than the number given, `lethargy.ArgsError` will be raised.
+If there are fewer values for the option than the number given, `lethargy.ArgsError` will be raised. See [Error Handling](#error-handling) for how to present this nicely.
 
 ```console
 $ python example.py --output
@@ -138,11 +148,13 @@ lethargy.errors.ArgsError: expected 1 argument for '-o|--output <value>', found 
 <hr>
 </details>
 
+###### GREEDINESS
+
 **Options can be variadic (greedy).** Use `...` instead of a number to take every value following the option.
 
 ```python
 # -i|--ignore [value]...
-ignored = lethargy.take(['i', 'ignore'], ...)
+ignored = lethargy.take_opt(['i', 'ignore'], ...)
 
 for pattern in ignored:
     print(pattern)
@@ -175,11 +187,13 @@ some.pyc
 <hr>
 </details>
 
+###### UNPACKING
+
 **Unpack multiple values into separate variables.** If the option wasn't present, they'll all be `None`.
 
 ```python
 # --name <value> <value> <value>
-first, middle, last = lethargy.take('name', 3)
+first, middle, last = lethargy.take_opt('name', 3)
 
 print(f'Hi, {first}!')
 ```
@@ -193,11 +207,13 @@ Hi, None!
 
 <br>
 
+###### DEFAULTS
+
 **Set sensible defaults.** Use the `or` keyword and your default value(s).
 
 ```python
 # -h|--set-hours <value> <value>
-start, finish = lethargy.take(['set hours', 'h'], 2) or "9AM", "5PM"
+start, finish = lethargy.take_opt(['set hours', 'h'], 2) or "9AM", "5PM"
 
 print(f'Employee now works {start} to {finish}')
 ```
@@ -211,11 +227,13 @@ Employee works 8AM to 4PM
 
 <br>
 
+###### TYPES & CONVERSION
+
 **Convert your option's values.** Use a function or type as the final argument. Defaults aren't converted.
 
 ```python
 # --date-ymd <int> <int> <int>
-y, m, d = lethargy.take('date ymd', 3, int) or 1970, 1, 1
+y, m, d = lethargy.take_opt('date ymd', 3, int) or 1970, 1, 1
 
 from datetime import datetime
 date = datetime(y, m, d)
@@ -230,12 +248,14 @@ it has been 7500 days since 1999-10-09 00:00:00
 
 <br>
 
+###### ERROR HANDLING
+
 **Give clear error messages.** Lucky for you, lethargy's errors are great by default. Just add 1 extra line!
 
 ```python
 with lethargy.show_errors():
-    n_bytes = lethargy.take('bytes', 1, int) or 8
-    start, end = lethargy.take(['r', 'range'], 2, int) or 0, 10
+    n_bytes = lethargy.take_opt('bytes', 1, int) or 8
+    start, end = lethargy.take_opt(['r', 'range'], 2, int) or 0, 10
 ```
 
 ```console
@@ -263,7 +283,7 @@ These context managers can be used together. Here's the example from [Usage](#us
 
 ```python
 with lethargy.show_errors(), lethargy.fail_on(IndexError, ValueError):
-    n_bytes = lethargy.take('bytes', 1, int) or 8
+    n_bytes = lethargy.take_opt('bytes', 1, int) or 8
     directory = lethargy.argv[1]
 ```
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,13 @@ with lethargy.show_errors():
     files = lethargy.argv[1:]
 ```
 
+```console
+$ python example.py --range 20
+expected 2 arguments for option '-r|--range <int> <int>', but found 1 ('20')
+$ python example.py --bytes
+expected 1 argument for option '--bytes <int>', but found none
+```
+
 <details>
 <summary align="right">Learn more about error handling</summary>
 <br>
@@ -319,6 +326,8 @@ with lethargy.show_errors(), lethargy.fail_on(IndexError, ValueError):
     n_bytes = lethargy.take('bytes', 1, int) or 8
     directory = lethargy.argv[1]
 ```
+
+To manually fail, call `lethargy.fail()`, optionally with a message.
 
 <hr>
 </details>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ pip install lethargy
 ```python
 import lethargy
 
+# --bytes <int>
 n_bytes = lethargy.take('bytes', 1, int) or 8
 
 # After removing --bytes and its value from argv, the dir should be first.
@@ -38,7 +39,7 @@ directory = lethargy.argv[1]
 That's an excerpt from a script I wrote for my job.
 
 <details>
-<summary>Show this example with manual extraction</summary>
+<summary>Show this example done manually</summary>
 <br>
 
 Done manually, there's a lot of detail that's not relevant to the actual script.
@@ -68,12 +69,11 @@ directory = sys.argv[1]
 ...
 ```
 
+<hr>
 </details>
 
-<br>
-
 <details>
-<summary>Show this example using Click instead</summary>
+<summary>Show this example using Click</summary>
 <br>
 
 Click _forces you into a specific style_ that just isn't great for some scripts. It requires a lot of boilerplate, and while you get a lot for free from that, it's also more to maintain and detracts from the script's _actual_ logic.
@@ -289,18 +289,39 @@ it has been 7500 days since 1999-10-09 00:00:00
 
 <br>
 
-**Give clear error messages.** Lucky for you, lethargy's errors are great.
+**Give clear error messages.** Lucky for you, lethargy's errors are great by default. Just add 1 extra line!
 
 ```python
-try:
+with lethargy.show_errors():
     n_bytes = lethargy.take('bytes', 1, int) or 8
     start, end = lethargy.take(['r', 'range'], 2, int) or 0, 10
     files = lethargy.argv[1:]
-except (lethargy.OptionError, ValueError) as err:
-    lethargy.fail(err)
 ```
 
+<details>
+<summary align="right">Learn more about error handling</summary>
 <br>
+
+Lethargy provides two context managers for easy error handling. These share similar behaviour, but are separate to make the intent more clear.
+
+> <i>with</i> <code><i>lethargy.</i><b>show_errors()</b></code>
+
+Shows any errors in option parsing to the user and exits with code 1.
+
+> <i>with</i> <code><i>lethargy.</i><b>fail_on(</b><i>*errors</i><b>)</b></code>
+
+Fails on the first raise of one of the given errors, printing it to stderr and exiting with code 1.
+
+These context managers can be used together. Here's the example from [Usage](#usage), but with just 1 extra line for better error handling.
+
+```python
+with lethargy.show_errors(), lethargy.fail_on(IndexError, ValueError):
+    n_bytes = lethargy.take('bytes', 1, int) or 8
+    directory = lethargy.argv[1]
+```
+
+<hr>
+</details>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # Lethargy: Terse & tiny command-line option library
 
-Lethargy is yet another small Python library for extracting options (and associated values) from a list of command-line arguments, specifically focused on being perfect for small to medium sized scripts. It gets out of your way as soon as possible to let you get on with the actual logic.
+**Lethargy was born out of frustration**, like most of my projects. It gets out of your way as soon as possible to let you get on with the actual logic. No bullshit, no magic, no objects to understand, you just call a function.
+
+I write a lot of small scripts to get my job done faster, and manually working with options is a pain. Existing libraries are extremely verbose or just don't feel good to use. _Lethargy is designed to make writing scripts easier and faster, and to reduce effort to maintain them_.
+
+<!-- Note that the spaces here are U+2000 (' ') EN QUAD -->
+<!--                 v                                  -->
+- **No boilerplate.** Headaches are directly proportional to lines of code.
+- **No bloat.** Small API surface area, very little to learn.
+- **No ambiguity.** Lethargy raises exceptions instead of getting your code into bad state.
+- **Clear errors.** Great error messages and context managers for dealing with them.
+- **Flexible.** You're not locked in to any styles or paradigms.
 
 Lethargy is completely imperative and is **not** a framework. If you _are_ building a complete CLI or want automatic help commands, you're better off using **[Click]** — a fantastic, declarative CLI framework.
 
@@ -32,7 +42,7 @@ with lethargy.expect(IndexError, reason="Missing required argument: [DIR]"):
 
 ## Getting Started
 
-For simplicity, all examples assume you've got `import lethargy` at the top.
+This is both a tutorial and the documentation. All examples assume you've got `import lethargy` at the top.
 
 ###### FLAGS
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
 # Lethargy: Good option parsing for your scripts
 
-[![Size]][Size URL]
+Lethargy is yet another small Python library for extracting options (and associated values) from a list of command-line arguments, specifically focused on being *perfect* for writing maintainable small to medium sized scripts. It's _extremely_ concise and unambiguous, with simple rules and great error handling.
 
-[Size]: https://img.shields.io/badge/size-14%20kB-blue
-[Size URL]: https://github.com/SeparateRecords/lethargy/tree/master/lethargy
-<!-- Size correct as at e4db57f (March 16, 2020) -->
-
-Lethargy is yet another small Python library for extracting options (and associated values) from a list of command-line arguments, specifically focused on being *perfect* for writing maintainable small to medium sized scripts.
-
-Lethargy is **not** a CLI framework. If you're building a complete CLI, you're better off using the amazing library **[Click]**, which has better suited design goals.
+Lethargy is completely imperative and is **not** a CLI framework. If you're building a complete CLI or _need_ automatic help commands, you're better off using **[Click]**, a truly fantastic declarative CLI framework.
 
 [Click]: https://click.palletsprojects.com/en/7.x/
 [Getting Started]: #getting-started
@@ -248,7 +242,7 @@ it has been 7500 days since 1999-10-09 00:00:00
 
 ###### ERROR HANDLING
 
-**Give clear error messages.** Lucky for you, lethargy's errors are great by default. Just add 1 extra line!
+**Give clear error messages.** Lucky for you, lethargy's errors are extremely descriptive.
 
 ```python
 with lethargy.show_errors():
@@ -262,7 +256,7 @@ Expected 2 arguments for option '-r|--range <int> <int>', but found 1 ('20')
 $ python example.py --bytes
 Expected 1 argument for option '--bytes <int>', but found none
 $ python example.py --bytes wrong
-Option '--bytes <int>' received invalid value: 'wrong'
+Option '--bytes <int>' received an invalid value: 'wrong'
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -6,13 +6,12 @@
 [Size URL]: https://github.com/SeparateRecords/lethargy/tree/master/lethargy
 <!-- Size correct as at e4db57f (March 16, 2020) -->
 
-It's not a full argument parser. If you're building a complete CLI, you're better off using the amazing library **[Click]**. Click has different design goals more suited for that use.
+Lethargy is yet another small Python library for extracting options (and associated values) from a list of command-line arguments, specifically focused on being *perfect* for writing maintainable small to medium sized scripts.
 
-Lethargy is yet another small library for extracting options from a list of command-line arguments. It's specifically **_designed for use in your scripts_** as a maintainable and _good_ alternative to manually extracting options (flags and values) from `sys.argv`.
-
-Lethargy uses its own copy of the arguments (`lethargy.argv`) and mutates that, unless you explicitly tell it not to.
+Lethargy is **not** a CLI framework. If you're building a complete CLI, you're better off using the amazing library **[Click]**, which has better suited design goals.
 
 [Click]: https://click.palletsprojects.com/en/7.x/
+[Getting Started]: #getting-started
 
 ## Installation
 
@@ -35,64 +34,6 @@ directory = lethargy.argv[1]
 
 ...
 ```
-
-That's an excerpt from a script I wrote for my job.
-
-<details>
-<summary>Show this example done manually</summary>
-<br>
-
-Done manually, there's a lot of detail that's not relevant to the actual script.
-* What happens if the option isn't present?
-* What happens if it is but has no value?
-* What about if that value isn't an int?
-* How do you communicate what went wrong?
-
-All these implementation details increase the maintenance and complexity. This shouldn't be handled by _you_.
-
-```python
-import sys
-
-try:
-    index = sys.argv.index("--bytes")
-    try:
-        n_bytes = int(sys.argv[index + 1])
-    except IndexError:
-        sys.exit(1)
-    del sys.argv[index : index + 2]
-except ValueError:
-    n_bytes = 8
-
-# After removing --bytes and its value from argv, the dir should be first.
-directory = sys.argv[1]
-
-...
-```
-
-<hr>
-</details>
-
-<details>
-<summary>Show this example using Click</summary>
-<br>
-
-Click _forces you into a specific style_ that just isn't great for some scripts. It requires a lot of boilerplate, and while you get a lot for free from that, it's also more to maintain and detracts from the script's _actual_ logic.
-
-```python
-import click
-
-@click.command()
-@click.option('--bytes', default=8)
-@click.argument('directory')
-def cli(bytes, directory):
-    ...
-
-if __name__ == '__main__':
-    cli()
-```
-
-<hr>
-</details>
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ import lethargy
 with lethargy.show_errors():
     n_bytes = lethargy.take_opt('bytes', 1, int) or 8
 
-# ``take_opt`` removes the option and its value from ``argv``.
+# The option and value have now been removed from lethargy.argv.
 # The directory is a mandatory argument, so we'll take it directly by its index.
-with lethargy.expect(IndexError, reason="Missing required argument <DIR>"):
+with lethargy.expect(IndexError, reason="Missing required argument: [DIR]"):
     directory = lethargy.argv[1]
 
 ...

--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ pip install lethargy
 ```python
 import lethargy
 
-# We'll take the option '--bytes <int>'.
-# The context manager provides some nice default error handling.
+# Accepts the option '--bytes <int>'. Show the error nicely if it goes wrong.
 with lethargy.show_errors():
     n_bytes = lethargy.take_opt('bytes', 1, int) or 8
 
-# The option and value have now been removed from lethargy.argv.
-# The directory is a mandatory argument, so we'll take it directly by its index.
+# The option and value have now been removed from lethargy.argv
 with lethargy.expect(IndexError, reason="Missing required argument: [DIR]"):
     directory = lethargy.argv[1]
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install lethargy
 
 ```python
 # --debug
-debug = lethargy.flag('debug')
+debug = lethargy.take('debug')
 
 print(debug)
 ```
@@ -42,11 +42,11 @@ False
 
 <br>
 
-**Options can have more than one name.** Instead of a string, use a list or tuple.
+**Options can have more than one name.** Instead of a string, use a list or tuple. Names are case-sensitive.
 
 ```python
 # -v|--verbose
-verbose = lethargy.flag(['v', 'verbose'])
+verbose = lethargy.take(['v', 'verbose'])
 
 print(verbose)
 ```
@@ -68,7 +68,7 @@ If you provide an explicit name (starting with a non-alphanumeric character, suc
 
 ```python
 # -Enable
-enabled = lethargy.flag('-Enable')
+enabled = lethargy.take('-Enable')
 print(enabled)
 ```
 
@@ -79,7 +79,7 @@ $ python example.py
 False
 ```
 
-Names are _always_ case sensitive. `-Enable` ≠ `-enable`
+Names are _always_ case sensitive. `-Enable` **≠** `-enable`
 
 ```console
 $ python example.py -enable
@@ -93,7 +93,7 @@ False
 
 ```python
 # -o|--output <value>
-output = lethargy.args(['o', 'output'], 1)
+output = lethargy.take(['o', 'output'], 1)
 
 print(output)
 ```
@@ -125,7 +125,7 @@ lethargy.errors.ArgsError: expected 1 argument for '-o|--output <value>', found 
 
 ```python
 # -i|--ignore [value]...
-ignored = lethargy.args(['i', 'ignore'], ...)
+ignored = lethargy.take(['i', 'ignore'], ...)
 
 for pattern in ignored:
     print(pattern)
@@ -147,7 +147,7 @@ $ python example.py
 
 ```python
 # --name <value> <value> <value>
-first, middle, last = lethargy.args('name', 3)
+first, middle, last = lethargy.take('name', 3)
 
 print(f'Hi, {first}!')
 ```
@@ -165,7 +165,7 @@ Hi, None!
 
 ```python
 # --range <value> <value>
-start, stop, step = lethargy.args('range', 2) or "2000", "2020"
+start, stop, step = lethargy.take('range', 2) or "2000", "2020"
 
 print(f'finding results from {start} to {stop}...')
 ```
@@ -183,7 +183,7 @@ finding results from 2000 to 2020...
 
 ```python
 # --date <int> <int> <int>
-y, m, d = lethargy.args('date', 3, float) or 1970, 1, 1
+y, m, d = lethargy.take('date', 3, float) or 1970, 1, 1
 
 from datetime import datetime
 date = datetime(y, m, d)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# Lethargy: Good option parsing for your scripts
+# Lethargy: Terse & tiny command-line option library
 
-Lethargy is yet another small Python library for extracting options (and associated values) from a list of command-line arguments, specifically focused on being *perfect* for writing maintainable small to medium sized scripts. It's _extremely_ concise and unambiguous, with simple rules and great error handling.
+Lethargy is yet another small Python library for extracting options (and associated values) from a list of command-line arguments, specifically focused on being perfect for small to medium sized scripts. It gets out of your way as soon as possible to let you get on with the actual logic.
 
-Lethargy is completely imperative and is **not** a CLI framework. If you're building a complete CLI or _need_ automatic help commands, you're better off using **[Click]**, a truly fantastic declarative CLI framework.
+Lethargy is completely imperative and is **not** a framework. If you _are_ building a complete CLI or want automatic help commands, you're better off using **[Click]** — a fantastic, declarative CLI framework.
 
 [Click]: https://click.palletsprojects.com/en/7.x/
-[Getting Started]: #getting-started
 
 ## Installation
 
@@ -24,7 +23,7 @@ import lethargy
 with lethargy.show_errors():
     n_bytes = lethargy.take_opt('bytes', 1, int) or 8
 
-# The option and value have now been removed from lethargy.argv
+# Now the option and value have been removed from lethargy.argv
 with lethargy.expect(IndexError, reason="Missing required argument: [DIR]"):
     directory = lethargy.argv[1]
 
@@ -57,7 +56,7 @@ False
 
 ###### NAMES
 
-**Options can have more than one name.** Instead of a string, use a list or tuple. Names are case-sensitive.
+**Options can have more than one name.** Instead of a string, use a list of strings. Names are case-sensitive.
 
 ```python
 # -v|--verbose

--- a/README.md
+++ b/README.md
@@ -295,7 +295,6 @@ it has been 7500 days since 1999-10-09 00:00:00
 with lethargy.show_errors():
     n_bytes = lethargy.take('bytes', 1, int) or 8
     start, end = lethargy.take(['r', 'range'], 2, int) or 0, 10
-    files = lethargy.argv[1:]
 ```
 
 ```console

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ True
 $ python example.py
 False
 ```
+
 <br>
 
 **Options can have more than one name.** Instead of a string, use a list or tuple.
@@ -58,13 +59,15 @@ True
 ```
 
 <details>
-<summary align="right">Read more about option names</summary>
+<summary align="right">Learn more about option names</summary>
 <br>
 
-Option names are automatically generated, but if you provide an explicit name (starting with a non-alphanumeric character, such as `-`, `/` or `+`), the name is stripped and treated as literal.
+Option names are automatically generated. `"use headers"` becomes `--use-headers`, and `"I"` becomes `-I`.
+
+If you provide an explicit name (starting with a non-alphanumeric character, such as `-`, `/` or `+`), the name is stripped and treated as literal.
 
 ```python
-# /enable
+# -Enable
 enabled = lethargy.flag('-Enable')
 print(enabled)
 ```
@@ -76,7 +79,7 @@ $ python example.py
 False
 ```
 
-Names are always case sensitive. `-Enable` ≠ `-enable`
+Names are _always_ case sensitive. `-Enable` ≠ `-enable`
 
 ```console
 $ python example.py -enable
@@ -90,7 +93,7 @@ False
 
 ```python
 # -o|--output <value>
-output = lethargy.args(1, ['o', 'output'])
+output = lethargy.args(['o', 'output'], 1)
 
 print(output)
 ```
@@ -103,7 +106,7 @@ None
 ```
 
 <details>
-<summary align="right">Read more about arguments</summary>
+<summary align="right">Learn more about arguments</summary>
 <br>
 
 If there are fewer values for the option than the number given, `lethargy.ArgsError` will be raised.
@@ -122,7 +125,7 @@ lethargy.errors.ArgsError: expected 1 argument for '-o|--output <value>', found 
 
 ```python
 # -i|--ignore [value]...
-ignored = lethargy.args(..., ['i', 'ignore'])
+ignored = lethargy.args(['i', 'ignore'], ...)
 
 for pattern in ignored:
     print(pattern)
@@ -144,7 +147,7 @@ $ python example.py
 
 ```python
 # --name <value> <value> <value>
-first, middle, last = lethargy.args(3, 'name')
+first, middle, last = lethargy.args('name', 3)
 
 print(f'Hi, {first}!')
 ```
@@ -158,11 +161,11 @@ Hi, None!
 
 <br>
 
-**Use defaults for when options aren't present** with the `or` keyword.
+**Set sensible defaults.** Use the `or` keyword and your default value(s).
 
 ```python
 # --range <value> <value>
-start, stop, step = lethargy.args(2, 'range') or "2000", "2020"
+start, stop, step = lethargy.args('range', 2) or "2000", "2020"
 
 print(f'finding results from {start} to {stop}...')
 ```
@@ -176,11 +179,11 @@ finding results from 2000 to 2020...
 
 <br>
 
-**Convert your option's values.** Use a function or type as the final argument.
+**Convert your option's values.** Use a function or type as the final argument. Defaults aren't converted.
 
 ```python
 # --date <int> <int> <int>
-y, m, d = lethargy.args(3, 'date', float) or 1970, 1, 1
+y, m, d = lethargy.args('date', 3, float) or 1970, 1, 1
 
 from datetime import datetime
 date = datetime(y, m, d)

--- a/README.md
+++ b/README.md
@@ -31,23 +31,26 @@ import sys
 
 try:
     index = sys.argv.index("--bytes")
-    n_bytes = int(sys.argv[index + 1])
+    try:
+        n_bytes = int(sys.argv[index + 1])
+    except IndexError:
+        sys.exit(1)
     del sys.argv[index : index + 2]
 except ValueError:
     n_bytes = 8
 
-# After removing --bytes and its value from argv, the dir should be the only arg left
+# After removing --bytes and its value from argv, the dir should be first.
 directory = sys.argv[1]
 
 ...
 ```
 
-Here's the same excerpt but using lethargy. It takes 1 line to do what 6 did manually, with pretty good error messages.
+Here's the same excerpt but using lethargy. It takes 1 line to do what 9 did manually, with pretty good error messages.
 
 ```python
 import lethargy
 
-# After removing --bytes and its value from argv, the dir should be the only arg left
+# After removing --bytes and its value from argv, the dir should be first.
 n_bytes = lethargy.take('bytes', 1, int) or 8
 directory = lethargy.argv[1]
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,8 @@ with lethargy.show_errors():
 
 # ``take_opt`` removes the option and its value from ``argv``.
 # The directory is a mandatory argument, so we'll take it directly by its index.
-try:
+with lethargy.expect(IndexError, reason="Missing required argument <DIR>"):
     directory = lethargy.argv[1]
-except IndexError:
-    lethargy.fail("Missing required directory")
 
 ...
 ```
@@ -260,9 +258,11 @@ with lethargy.show_errors():
 
 ```console
 $ python example.py --range 20
-expected 2 arguments for option '-r|--range <int> <int>', but found 1 ('20')
+Expected 2 arguments for option '-r|--range <int> <int>', but found 1 ('20')
 $ python example.py --bytes
-expected 1 argument for option '--bytes <int>', but found none
+Expected 1 argument for option '--bytes <int>', but found none
+$ python example.py --bytes wrong
+Option '--bytes <int>' received invalid value: 'wrong'
 ```
 
 <details>
@@ -273,20 +273,19 @@ Calling `fail()` will exit with status code 1. You can optionally use a message.
 
 Lethargy provides two context managers for easier error handling. These share similar behaviour, but are separate to make intent clearer.
 
-> <i>with</i> <code><i>lethargy.</i><b>fail_on(</b><i>*errors</i><b>)</b></code>
+> <i>with</i> <code><i>lethargy.</i><b>expect(</b><i>*errors: Exception</i>, <i>reason: Optional[str] = None</i><b>)</b></code>
 
 When one of the given exceptions is raised, it calls `fail()` to exit and print the message.
 
 > <i>with</i> <code><i>lethargy.</i><b>show_errors()</b></code>
 
-Same as `fail_on` but specifically for `lethargy.OptionError`.
+Same behaviour as `expect`, but specifically for exceptions from lethargy.
 
-These context managers can be used together.
+Note that exceptions raised during value conversions will be caught by `show_errors()`.
 
-```python
-with lethargy.show_errors(), lethargy.fail_on(ValueError):
-    n_bytes = lethargy.take_opt('bytes', 1, int) or 8
-```
+You can access the original exception that caused a `TransformError` with the `__cause__` attribute (see the Python [Built-in Exceptions] docs).
+
+[Built-in Exceptions]: https://docs.python.org/3/library/exceptions.html
 
 <hr>
 </details>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lethargy: Lazy option parsing for scripts
+# Lethargy: Good option parsing for your scripts
 
 [![Size]][Size URL]
 
@@ -8,9 +8,9 @@
 
 It's not a full argument parser. If you're building a complete CLI, you're better off using the amazing library **[Click]**. Click has different design goals more suited for that use.
 
-Lethargy takes care of **_option parsing_** in your **_scripts_**, so you can handle its arguments yourself. It's concise and explicit.
+Lethargy is yet another small library for extracting options from a list of command-line arguments. It's specifically **_designed for use in your scripts_** as a maintainable and _good_ alternative to manually extracting options (flags and values) from `sys.argv`.
 
-Lethargy is designed around mutating a list of arguments (`lethargy.argv` by default). This leaves you free to do whatever you want with what's left, after you've taken just the options you want. It is intended as a simple and maintainable improvement to manually parsing `sys.argv`.
+Lethargy uses its own copy of the arguments (`lethargy.argv`) and mutates that, unless you explicitly tell it not to.
 
 [Click]: https://click.palletsprojects.com/en/7.x/
 
@@ -22,7 +22,65 @@ You can use pip to install lethargy. It's tiny and only depends on the standard 
 pip install lethargy
 ```
 
+## Usage
+
+Here's an excerpt from script I wrote for work, without lethargy.
+
+```python
+import sys
+
+try:
+    index = sys.argv.index("--bytes")
+    n_bytes = int(sys.argv[index + 1])
+    del sys.argv[index : index + 2]
+except ValueError:
+    n_bytes = 8
+
+# After removing --bytes and its value from argv, the dir should be the only arg left
+directory = sys.argv[1]
+
+...
+```
+
+Here's the same excerpt but using lethargy. It takes 1 line to do what 6 did manually, with pretty good error messages.
+
+```python
+import lethargy
+
+# After removing --bytes and its value from argv, the dir should be the only arg left
+n_bytes = lethargy.take('bytes', 1, int) or 8
+directory = lethargy.argv[1]
+
+...
+```
+
+<details>
+<summary>Show this example using Click</summary>
+<br>
+
+Click _forces you into a specific style_ that just isn't great for some scripts. It requires a lot of boilerplate, and while you get a lot for free from that, it's also more to maintain and detracts from the script's _actual_ logic.
+
+```python
+import click
+
+@click.command()
+@click.option('--bytes', default=8)
+@click.argument('directory')
+def cli(bytes, directory):
+    ...
+
+if __name__ == '__main__':
+    cli()
+```
+
+<hr>
+</details>
+
 ## Getting Started
+
+For simplicity, all examples assume you've got `import lethargy` at the top.
+
+<br>
 
 **Options can be flags.** `True` if present, `False` if not.
 
@@ -139,9 +197,24 @@ $ python example.py --ignore .git .vscode .DS_Store
 $ python example.py --ignore experiments
 experiments
 $ python example.py
+$ ▏
 ```
 
+<details>
+<summary align="right">Learn more about variadic options</summary>
 <br>
+
+Because variadic options will take every argument, including values that look like other options, you should try and take these last (_after_ taking the fixed-count options).
+
+```console
+$ python example.py --ignore "*.pyc" --exceptions some.pyc
+*.pyc
+--exceptions
+some.pyc
+```
+
+<hr>
+</details>
 
 **Unpack multiple values into separate variables.** If the option wasn't present, they'll all be `None`.
 
@@ -164,17 +237,17 @@ Hi, None!
 **Set sensible defaults.** Use the `or` keyword and your default value(s).
 
 ```python
-# --range <value> <value>
-start, stop, step = lethargy.take('range', 2) or "2000", "2020"
+# -h|--set-hours <value> <value>
+start, finish = lethargy.take(['set hours', 'h'], 2) or "9AM", "5PM"
 
-print(f'finding results from {start} to {stop}...')
+print(f'Employee now works {start} to {finish}')
 ```
 
 ```console
-$ python example.py --range 2007 2016
-finding results from 2007 to 2016...
 $ python example.py
-finding results from 2000 to 2020...
+Employee works 9AM to 5PM
+$ python example.py --set-hours 8AM 4PM
+Employee works 8AM to 4PM
 ```
 
 <br>
@@ -182,8 +255,8 @@ finding results from 2000 to 2020...
 **Convert your option's values.** Use a function or type as the final argument. Defaults aren't converted.
 
 ```python
-# --date <int> <int> <int>
-y, m, d = lethargy.take('date', 3, float) or 1970, 1, 1
+# --date-ymd <int> <int> <int>
+y, m, d = lethargy.take('date ymd', 3, int) or 1970, 1, 1
 
 from datetime import datetime
 date = datetime(y, m, d)
@@ -192,7 +265,7 @@ print(f'it has been {delta.days} days since {date}')
 ```
 
 ```console
-$ python example.py --date 1999 10 9
+$ python example.py --date-ymd 1999 10 9
 it has been 7500 days since 1999-10-09 00:00:00
 ```
 
@@ -200,7 +273,7 @@ it has been 7500 days since 1999-10-09 00:00:00
 
 ## Contributing
 
-Any and all contributions are absolutely welcome. Feel free to open an issue or just jump straight to a PR.
+Any and all contributions are absolutely welcome. Feel free to open an issue or just jump straight to a PR. Let's discuss and make this the best it can be! 😄
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -269,25 +269,24 @@ expected 1 argument for option '--bytes <int>', but found none
 <summary align="right">Learn more about error handling</summary>
 <br>
 
-Lethargy provides two context managers for easy error handling. These share similar behaviour, but are separate to make the intent more clear.
+Calling `fail()` will exit with status code 1. You can optionally use a message.
 
-> <i>with</i> <code><i>lethargy.</i><b>show_errors()</b></code>
-
-Shows any errors in option parsing to the user and exits with code 1.
+Lethargy provides two context managers for easier error handling. These share similar behaviour, but are separate to make intent clearer.
 
 > <i>with</i> <code><i>lethargy.</i><b>fail_on(</b><i>*errors</i><b>)</b></code>
 
-Fails on the first raise of one of the given errors, printing it to stderr and exiting with code 1.
+When one of the given exceptions is raised, it calls `fail()` to exit and print the message.
 
-These context managers can be used together. Here's the example from [Usage](#usage), but with just 1 extra line for better error handling.
+> <i>with</i> <code><i>lethargy.</i><b>show_errors()</b></code>
+
+Same as `fail_on` but specifically for `lethargy.OptionError`.
+
+These context managers can be used together.
 
 ```python
-with lethargy.show_errors(), lethargy.fail_on(IndexError, ValueError):
+with lethargy.show_errors(), lethargy.fail_on(ValueError):
     n_bytes = lethargy.take_opt('bytes', 1, int) or 8
-    directory = lethargy.argv[1]
 ```
-
-To manually fail, call `lethargy.fail()`, optionally with a message.
 
 <hr>
 </details>

--- a/lethargy/__init__.py
+++ b/lethargy/__init__.py
@@ -7,8 +7,8 @@ __all__ = (
     # --------------------
     "take_opt",
     "argv",
+    "expect",
     "show_errors",
-    "fail_on",
 
     # Original interface
     # ------------------
@@ -24,6 +24,7 @@ __all__ = (
     # ---------------
     "ArgsError",
     "MissingOption",
+    "TransformError",
     "OptionError",
 
     # Legacy
@@ -33,12 +34,12 @@ __all__ = (
 )
 # fmt: on
 
-from lethargy.errors import ArgsError, MissingOption, OptionError
+from lethargy.errors import ArgsError, MissingOption, OptionError, TransformError
 from lethargy.option import Opt, take_opt
-from lethargy.util import argv, eprint, fail, fail_on, print_if, show_errors
+from lethargy.util import argv, eprint, expect, fail, print_if, show_errors
 
-# The following options are such a frequent usage of this library that it's
-# reasonable to provide them automatically, and remove even more boilerplate.
+# The following options will be removed in version 3.0 because take_opt makes
+# them redundant. It's clearer and nearly as fast to use `take_opt('debug')`.
 
 take_debug = Opt("debug").take_flag
 take_verbose = Opt("v", "verbose").take_flag

--- a/lethargy/__init__.py
+++ b/lethargy/__init__.py
@@ -1,20 +1,38 @@
 """Declarative, dynamic option parsing."""
 
+# fmt: off
 __version__ = "2.0.1"
 __all__ = (
-    "ArgsError",
-    "MissingOption",
+    # Simplified interface
+    # --------------------
+    "args",
+    "flag",
+
+    # Original interface
+    # ------------------
     "Opt",
-    "OptionError",
     "argv",
+
+    # Utility
+    # -------
     "eprint",
     "print_if",
+
+    # Technical stuff
+    # ---------------
+    "ArgsError",
+    "MissingOption",
+    "OptionError",
+
+    # Legacy
+    # ------
     "take_debug",
     "take_verbose",
 )
+# fmt: on
 
 from lethargy.errors import ArgsError, MissingOption, OptionError
-from lethargy.option import Opt
+from lethargy.option import Opt, args, flag
 from lethargy.util import argv, eprint, print_if
 
 # The following options are such a frequent usage of this library that it's

--- a/lethargy/__init__.py
+++ b/lethargy/__init__.py
@@ -1,7 +1,7 @@
 """Declarative, dynamic option parsing."""
 
 # fmt: off
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 __all__ = (
     # Simplified interface
     # --------------------

--- a/lethargy/__init__.py
+++ b/lethargy/__init__.py
@@ -5,7 +5,7 @@ __version__ = "2.0.1"
 __all__ = (
     # Simplified interface
     # --------------------
-    "take",
+    "take_opt",
     "argv",
     "show_errors",
     "fail_on",
@@ -34,7 +34,7 @@ __all__ = (
 # fmt: on
 
 from lethargy.errors import ArgsError, MissingOption, OptionError
-from lethargy.option import Opt, take
+from lethargy.option import Opt, take_opt
 from lethargy.util import argv, eprint, fail, fail_on, print_if, show_errors
 
 # The following options are such a frequent usage of this library that it's

--- a/lethargy/__init__.py
+++ b/lethargy/__init__.py
@@ -5,13 +5,12 @@ __version__ = "2.0.1"
 __all__ = (
     # Simplified interface
     # --------------------
-    "args",
-    "flag",
+    "take",
+    "argv",
 
     # Original interface
     # ------------------
     "Opt",
-    "argv",
 
     # Utility
     # -------
@@ -32,7 +31,7 @@ __all__ = (
 # fmt: on
 
 from lethargy.errors import ArgsError, MissingOption, OptionError
-from lethargy.option import Opt, args, flag
+from lethargy.option import Opt, take
 from lethargy.util import argv, eprint, print_if
 
 # The following options are such a frequent usage of this library that it's

--- a/lethargy/__init__.py
+++ b/lethargy/__init__.py
@@ -7,6 +7,8 @@ __all__ = (
     # --------------------
     "take",
     "argv",
+    "show_errors",
+    "fail_on",
 
     # Original interface
     # ------------------
@@ -33,7 +35,7 @@ __all__ = (
 
 from lethargy.errors import ArgsError, MissingOption, OptionError
 from lethargy.option import Opt, take
-from lethargy.util import argv, eprint, fail, print_if
+from lethargy.util import argv, eprint, fail, fail_on, print_if, show_errors
 
 # The following options are such a frequent usage of this library that it's
 # reasonable to provide them automatically, and remove even more boilerplate.

--- a/lethargy/__init__.py
+++ b/lethargy/__init__.py
@@ -15,6 +15,7 @@ __all__ = (
     # Utility
     # -------
     "eprint",
+    "fail",
     "print_if",
 
     # Technical stuff
@@ -32,7 +33,7 @@ __all__ = (
 
 from lethargy.errors import ArgsError, MissingOption, OptionError
 from lethargy.option import Opt, take
-from lethargy.util import argv, eprint, print_if
+from lethargy.util import argv, eprint, fail, print_if
 
 # The following options are such a frequent usage of this library that it's
 # reasonable to provide them automatically, and remove even more boilerplate.

--- a/lethargy/errors.py
+++ b/lethargy/errors.py
@@ -1,6 +1,10 @@
 """Module specifically to contain exception subclasses."""
 
 
+class TransformError(Exception):
+    """Tranforming an option raised an exception."""
+
+
 class OptionError(Exception):
     """Superclass of ArgsError and MissingOption."""
 

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -178,13 +178,13 @@ class Opt:
             return self._tfm(value)
 
         except Exception as exc:
-            message = f"Option '{self}' received invalid value: {value!r}"
+            message = f"Option '{self}' received an invalid value: {value!r}"
 
             # The exception needs to be a subclass of both the raised exception
             # and TransformError. This allows manually handling specific
             # exception types, _and_ automatically handling any exceptions that
             # get raised during transformation.
-            name = "<TransformationException>"
+            name = f"<TransformError | {exc.__class__.__name__}>"
             bases = (exc.__class__, TransformError)
             new_exc = type(name, bases, {})
 

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -149,9 +149,9 @@ class Opt:
             # Fail fast if the option expects more arguments than it has.
             if end_idx > len(args):
                 # Highest index (length - 1) minus this option's index.
-                actual = len(args) - 1 - index
+                n_args_present = len(args) - 1 - index
+                actual = n_args_present if n_args_present else "none"
                 s = "s" if argc != 1 else ""
-                actual = len(args) - 1 - index
                 msg = f"expected {argc} argument{s} for option '{self}', found {actual}"
                 if actual:
                     found = ", ".join(map(repr, args[index + 1 : end_idx]))

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -1,6 +1,7 @@
 """Defines the Opt class (main interface)."""
 
 from copy import copy
+from functools import lru_cache
 
 from lethargy.errors import ArgsError, MissingOption
 from lethargy.util import argv, falsylist, identity, is_greedy, stab
@@ -172,3 +173,17 @@ class Opt:
 
         # Return a list of transformed values.
         return [self._tfm(x) for x in taken]
+
+
+@lru_cache
+def flag(name, *, args=argv):
+    """Quickly take a flag."""
+    names = [name] if isinstance(name, str) else name
+    return Opt(*names).take_flag(args)
+
+
+@lru_cache
+def args(name, number=1, call=None, *, args=argv, required=False):
+    """Quickly take arguments."""
+    names = [name] if isinstance(name, str) else name
+    return Opt(*names).takes(number, call).take_args(args, raises=required)

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -117,8 +117,10 @@ class Opt:
         # Taking less than 1 argument will do nothing, use take_flag instead.
         # Assume argc is numeric if it's not greedy.
         if not is_greedy(argc) and argc < 1:
-            msg = "'{}' takes {} arguments (did you mean to use `take_flag`?)"
-            raise ArgsError(msg.format(self, "no" if argc == 0 else argc))
+            s = "s" if argc != 1 else ""
+            n = "no" if argc == 0 else argc
+            msg = f"'{self}' takes {n} argument{s} (did you mean to use `take_flag`?)"
+            raise ArgsError(msg)
 
         # Is this option in the list?
         index = self._find_in(args)

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -149,13 +149,13 @@ class Opt:
             # Fail fast if the option expects more arguments than it has.
             if end_idx > len(args):
                 # Highest index (length - 1) minus this option's index.
-                n_args_present = len(args) - 1 - index
-                actual = n_args_present if n_args_present else "none"
+                actual = len(args) - 1 - index
+                n = actual or "none"
                 s = "s" if argc != 1 else ""
-                msg = f"expected {argc} argument{s} for option '{self}', found {actual}"
+                msg = f"expected {argc} argument{s} for option '{self}', but found {n}"
                 if actual:
-                    found = ", ".join(map(repr, args[index + 1 : end_idx]))
-                    msg += f" ({found})"
+                    present_args = ", ".join(map(repr, args[index + 1 : end_idx]))
+                    msg += f" ({present_args})"
                 raise ArgsError(msg)
 
         # Get the list of values starting from the first value to the option.

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -126,7 +126,7 @@ class Opt:
         # Return early if the option isn't present.
         if index is None:
             if raises:
-                msg = f"'{self}' was not found in {args}"
+                msg = f"Missing required option '{self}'"
                 raise MissingOption(msg)
 
             if is_greedy(argc):

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -173,7 +173,7 @@ class Opt:
         return [self._tfm(x) for x in taken]
 
 
-def take(name, number=None, call=None, *, args=argv, required=False, mut=True):
+def take_opt(name, number=None, call=None, *, args=argv, required=False, mut=True):
     """Quickly take an option as flag, or with some arguments."""
     names = [name] if isinstance(name, str) else name
     opt = Opt(*names)

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -119,7 +119,7 @@ class Opt:
         # Assume argc is numeric if it's not greedy.
         if not is_greedy(argc) and argc < 1:
             msg = "{} takes {} arguments (did you mean to use `take_flag`?)"
-            raise ArgsError(msg.format(self, argc))
+            raise ArgsError(msg.format(self, "no" if argc == 0 else argc))
 
         # Is this option in the list?
         index = self._find_in(args)

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -173,7 +173,7 @@ class Opt:
         return [self._transform(x) for x in taken]
 
     def _transform(self, value):
-        """Call _tfm on a string and return the result, or raise a special exception."""
+        """Call _tfm on a string and return the result, or raise an exception union."""
         try:
             return self._tfm(value)
 

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -1,7 +1,6 @@
 """Defines the Opt class (main interface)."""
 
 from copy import copy
-from functools import lru_cache
 
 from lethargy.errors import ArgsError, MissingOption
 from lethargy.util import argv, falsylist, identity, is_greedy, stab
@@ -181,7 +180,7 @@ def flag(name, *, args=argv):
     return Opt(*names).take_flag(args)
 
 
-def args(number, name, call=None, *, args=argv, required=False):
+def args(name, number, call=None, *, args=argv, required=False):
     """Quickly take arguments."""
     names = [name] if isinstance(name, str) else name
     return Opt(*names).takes(number, call).take_args(args, raises=required)

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -174,13 +174,10 @@ class Opt:
         return [self._tfm(x) for x in taken]
 
 
-def flag(name, *, args=argv):
-    """Quickly take a flag."""
+def take(name, number=None, call=None, *, args=argv, required=False, mut=True):
+    """Quickly take an option as flag, or with some arguments."""
     names = [name] if isinstance(name, str) else name
-    return Opt(*names).take_flag(args)
-
-
-def args(name, number, call=None, *, args=argv, required=False):
-    """Quickly take arguments."""
-    names = [name] if isinstance(name, str) else name
-    return Opt(*names).takes(number, call).take_args(args, raises=required)
+    opt = Opt(*names)
+    if not number:
+        return opt.take_flag(args, mut=mut)
+    return opt.takes(number, call).take_args(args, raises=required, mut=mut)

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -3,7 +3,7 @@
 from copy import copy
 
 from lethargy.errors import ArgsError, MissingOption
-from lethargy.util import argv, identity, is_greedy, stab
+from lethargy.util import argv, falsylist, identity, is_greedy, stab
 
 
 class Opt:
@@ -110,7 +110,7 @@ class Opt:
 
         return True
 
-    def take_args(self, args=argv, *, d=None, raises=False, mut=True):
+    def take_args(self, args=argv, *, raises=False, mut=True, d=None):
         """Get the values of this option."""
         argc = self._argc
 
@@ -130,10 +130,10 @@ class Opt:
                 raise MissingOption(msg)
 
             if is_greedy(argc):
-                return [] if d is None else d
+                return falsylist() if d is None else d
 
             if d is None and argc != 1:
-                return [None] * argc
+                return falsylist([None] * argc)
 
             # `if d is None and argc == 1` should return None anyway. As long
             # as d is None by default then this always returns correctly.

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -175,15 +175,13 @@ class Opt:
         return [self._tfm(x) for x in taken]
 
 
-@lru_cache
 def flag(name, *, args=argv):
     """Quickly take a flag."""
     names = [name] if isinstance(name, str) else name
     return Opt(*names).take_flag(args)
 
 
-@lru_cache
-def args(name, number=1, call=None, *, args=argv, required=False):
+def args(number, name, call=None, *, args=argv, required=False):
     """Quickly take arguments."""
     names = [name] if isinstance(name, str) else name
     return Opt(*names).takes(number, call).take_args(args, raises=required)

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -149,15 +149,14 @@ class Opt:
             # Fail fast if the option expects more arguments than it has.
             if end_idx > len(args):
                 # Highest index (length - 1) minus this option's index.
-                msg = "expected {n} argument{s} for '{self}', found {actual} ({args})"
-                formatted = msg.format(
-                    n=argc,
-                    s="s" if argc != 1 else "",
-                    self=str(self),
-                    actual=len(args) - 1 - index,
-                    args=", ".join(map(repr, args[index + 1 : end_idx])),
-                )
-                raise ArgsError(formatted)
+                actual = len(args) - 1 - index
+                s = "s" if argc != 1 else ""
+                actual = len(args) - 1 - index
+                msg = f"expected {argc} argument{s} for option '{self}', found {actual}"
+                if actual:
+                    found = ", ".join(map(repr, args[index + 1 : end_idx]))
+                    msg += f" ({found})"
+                raise ArgsError(msg)
 
         # Get the list of values starting from the first value to the option.
         taken = args[index + 1 : end_idx]

--- a/lethargy/util.py
+++ b/lethargy/util.py
@@ -63,4 +63,12 @@ def print_if(condition):
 
 eprint = functools.partial(print, file=sys.stderr)
 
+
+def fail(message=None):
+    """Print a message to stderr and exit with code 1."""
+    if message:
+        eprint(message)
+    sys.exit(1)
+
+
 falsylist = type("falsylist", (list,), {"__bool__": lambda _: False})

--- a/lethargy/util.py
+++ b/lethargy/util.py
@@ -62,3 +62,5 @@ def print_if(condition):
 
 
 eprint = functools.partial(print, file=sys.stderr)
+
+falsylist = type("falsylist", (list,), {"__bool__": lambda _: False})

--- a/lethargy/util.py
+++ b/lethargy/util.py
@@ -1,7 +1,10 @@
 """Functions and values, independent of other modules."""
 
+import contextlib
 import functools
 import sys
+
+from lethargy.errors import OptionError
 
 # Lethargy provides its own argv so you don't have to import sys or worry
 # about mutating the original.
@@ -67,8 +70,26 @@ eprint = functools.partial(print, file=sys.stderr)
 def fail(message=None):
     """Print a message to stderr and exit with code 1."""
     if message:
-        eprint(message)
+        print(message, file=sys.stderr)
     sys.exit(1)
+
+
+@contextlib.contextmanager
+def show_errors():
+    """Call `fail()` if any OptionErrors are raised."""
+    try:
+        yield
+    except OptionError as e:
+        fail(e)
+
+
+@contextlib.contextmanager
+def fail_on(*errors):
+    """Call `fail()` if any given errors are raised."""
+    try:
+        yield
+    except errors as e:
+        fail(e)
 
 
 falsylist = type("falsylist", (list,), {"__bool__": lambda _: False})

--- a/lethargy/util.py
+++ b/lethargy/util.py
@@ -64,23 +64,11 @@ def print_if(condition):
     return print if condition else lambda *__, **_: None
 
 
-eprint = functools.partial(print, file=sys.stderr)
-
-
 def fail(message=None):
     """Print a message to stderr and exit with code 1."""
     if message:
         print(message, file=sys.stderr)
     sys.exit(1)
-
-
-@contextlib.contextmanager
-def show_errors():
-    """Call `fail()` if any OptionErrors are raised."""
-    try:
-        yield
-    except OptionError as e:
-        fail(e)
 
 
 @contextlib.contextmanager
@@ -91,5 +79,9 @@ def fail_on(*errors):
     except errors as e:
         fail(e)
 
+
+show_errors = lambda: fail_on(OptionError)
+
+eprint = functools.partial(print, file=sys.stderr)
 
 falsylist = type("falsylist", (list,), {"__bool__": lambda _: False})

--- a/lethargy/util.py
+++ b/lethargy/util.py
@@ -4,7 +4,7 @@ import contextlib
 import functools
 import sys
 
-from lethargy.errors import OptionError
+from lethargy.errors import OptionError, TransformError
 
 # Lethargy provides its own argv so you don't have to import sys or worry
 # about mutating the original.
@@ -72,15 +72,15 @@ def fail(message=None):
 
 
 @contextlib.contextmanager
-def fail_on(*errors):
+def expect(*errors, reason=None):
     """Call `fail()` if any given errors are raised."""
     try:
         yield
     except errors as e:
-        fail(e)
+        fail(reason or e)
 
 
-show_errors = lambda: fail_on(OptionError)
+show_errors = lambda: expect(OptionError, TransformError)
 
 eprint = functools.partial(print, file=sys.stderr)
 

--- a/pylintrc
+++ b/pylintrc
@@ -3,4 +3,5 @@ max-line-length = 88
 
 [MESSAGES CONTROL]
 disable =
-  invalid-name
+  invalid-name,
+  redefined-outer-name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lethargy"
-version = "2.0.1"
+version = "2.1.0"
 description = "A minimal library to make your option-parsing easier."
 license = "MIT"
 repository = "https://github.com/SeparateRecords/lethargy"

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -181,3 +181,28 @@ def test_converter_multiple_values(opt):
     values = opt.take_args(["--test", "0", "1", "2", "3"])
     for val in values:
         assert isinstance(val, int)
+
+
+def test_transform_calls_tfm_function_with_value():
+    expected = []
+
+    class MockOpt:
+        def _tfm(self, value):
+            return value
+
+    assert Opt._transform(MockOpt(), expected) is expected
+
+
+def test_transform_raises_exception_with_correct_exception():
+    class CustomException(Exception):
+        pass
+
+    class MockOpt:
+        def _tfm(self, _):
+            raise CustomException
+
+    with pytest.raises(CustomException):
+        Opt._transform(MockOpt(), "")
+
+    with pytest.raises(lethargy.TransformError):
+        Opt._transform(MockOpt(), "")

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -100,6 +100,11 @@ def test_take_args_not_found_default_none_greedy_returns_empty_list(args):
     assert args == all_args()
 
 
+@pytest.mark.parametrize("amt", (2, ...))
+def test_take_args_not_found_default_none_return_value_is_falsy(args, amt):
+    assert not Opt("w").takes(amt).take_args(args)
+
+
 # opt not found, default not none, raises false
 @pytest.mark.parametrize("amt", (1, 2, ...))
 def test_take_args_not_found_default_not_none_returns_default(args, amt):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,10 @@ def test_argv_is_not_sys_argv():
     assert lethargy.argv is not sys.argv
 
 
+def test_argv_equals_sys_argv():
+    assert lethargy.argv == sys.argv
+
+
 def test_falsylist_is_list():
     assert isinstance(lethargy.util.falsylist(), list)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,16 +24,23 @@ def test_falsylist_is_list():
     assert isinstance(lethargy.util.falsylist(), list)
 
 
-def test_falsylist_is_falsy():
-    assert not lethargy.util.falsylist()
-    assert not lethargy.util.falsylist([])
-    assert not lethargy.util.falsylist([None])
-    assert not lethargy.util.falsylist([1, 2, 3])
+def test_falsylist_is_always_falsy():
+    # falsylist should not require itself to return false -- it's always falsy.
+    assert lethargy.util.falsylist.__bool__(None) is False
 
 
-def test_fail_exits():
+@pytest.mark.parametrize("message", (None, "Message"))
+def test_fail_exits(message):
     with pytest.raises(SystemExit):
-        lethargy.fail()
+        lethargy.fail(message)
+
+
+@pytest.mark.parametrize("message", (None, "Message"))
+def test_fail_exits_with_code_1(message):
+    try:
+        lethargy.fail(message)
+    except SystemExit as e:
+        assert e.code == 1
 
 
 def test_fail_prints_message_to_stderr(capsys):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,3 +11,14 @@ import lethargy
 
 def test_argv_is_not_sys_argv():
     assert lethargy.argv is not sys.argv
+
+
+def test_falsylist_is_list():
+    assert isinstance(lethargy.util.falsylist(), list)
+
+
+def test_falsylist_is_falsy():
+    assert not lethargy.util.falsylist()
+    assert not lethargy.util.falsylist([])
+    assert not lethargy.util.falsylist([None])
+    assert not lethargy.util.falsylist([1, 2, 3])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,10 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=protected-access
 
+import contextlib
 import sys
+
+import pytest
 
 import lethargy
 
@@ -26,3 +29,40 @@ def test_falsylist_is_falsy():
     assert not lethargy.util.falsylist([])
     assert not lethargy.util.falsylist([None])
     assert not lethargy.util.falsylist([1, 2, 3])
+
+
+def test_fail_exits():
+    with pytest.raises(SystemExit):
+        lethargy.fail()
+
+
+def test_fail_prints_message_to_stderr(capsys):
+    with contextlib.suppress(SystemExit):
+        lethargy.fail("Message!")
+    out, err = capsys.readouterr()
+    assert err == "Message!\n"
+    assert out == ""
+
+
+def test_fail_without_message_prints_nothing(capsys):
+    with contextlib.suppress(SystemExit):
+        lethargy.fail()
+    out, err = capsys.readouterr()
+    assert out == err == ""
+
+
+@pytest.mark.parametrize("current_err", (ValueError, IndexError))
+def test_fail_on(capsys, current_err):
+    with contextlib.suppress(SystemExit):
+        with lethargy.fail_on(ValueError, IndexError):
+            raise current_err("Uh oh!")
+    _, err = capsys.readouterr()
+    assert err == "Uh oh!\n"
+
+
+def test_show_errors(capsys):
+    with contextlib.suppress(SystemExit):
+        with lethargy.show_errors():
+            raise lethargy.OptionError("damn")
+    _, err = capsys.readouterr()
+    assert err == "damn\n"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,12 +59,20 @@ def test_fail_without_message_prints_nothing(capsys):
 
 
 @pytest.mark.parametrize("current_err", (ValueError, IndexError))
-def test_fail_on(capsys, current_err):
+def test_expect(capsys, current_err):
     with contextlib.suppress(SystemExit):
-        with lethargy.fail_on(ValueError, IndexError):
+        with lethargy.expect(ValueError, IndexError):
             raise current_err("Uh oh!")
     _, err = capsys.readouterr()
     assert err == "Uh oh!\n"
+
+
+def test_expect_custom_message_overrides_exception_message(capsys):
+    with contextlib.suppress(SystemExit):
+        with lethargy.expect(RuntimeError, reason="yikes"):
+            raise RuntimeError("Uh oh!")
+    _, err = capsys.readouterr()
+    assert err == "yikes\n"
 
 
 def test_show_errors(capsys):


### PR DESCRIPTION
2.1 is a significant change from 2.0 in style, but it maintains full backwards compatibility. 3.0 will drop all backwards compatibility with 2.0.x.

Leaving this until tomorrow afternoon because I'll inevitably think of something else to do.

## API Changes

Everything new is documented in the new README. TL;DR:

* Rewrote README (removed documentation of <2.1 features).
* `take_opt` function replaces usage of `Opt`.
* `expect` and `show_errors` context managers for error handling.

## Internal changes

* List returned by `Opt.take_args` when the option isn't present is now always falsy.
* Added `Opt._transform` for better exception handling.
* Improved error messages (language & formatting).
* Added "publish" workflow.

## Plans for 3.0

* The `d` keyword in `Opt.take_args` will be removed.
* The `raises` keyword in `Opt.take_args` will be renamed to `required`.
* `Opt` will become exclusively internal.
* `take_debug` and `take_verbose` will be removed.
* `print_if` will be removed.
* `eprint` will be removed.

Version 2.1 has resolved blocking issues with making these breaking changes. The goal is to finally finish reducing the scope of the library, as 2.0 still holds cruft from when lethargy was my dumping ground for the stuff I needed frequently.
