### PR TITLE
Version 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,14 +125,3 @@ dmypy.json
 
 # OS
 .DS_Store
-
-# Build
-*.lock
-
-# IDE
-.vscode/
-.idea/
-
-# experimental stuff
-sketchbook/
-experiments/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "python.jediEnabled": false,
     "python.formatting.provider": "black",
     "python.linting.pylintEnabled": true,
     "python.testing.pytestEnabled": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python.formatting.provider": "black",
+    "python.linting.pylintEnabled": true,
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": ["tests"],
+}

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ True
 
 <table><tbody><tr><td>💡</td><td>
 <!-- <tip> -->
-Option names are created automatically (POSIX style) if the given names start with a letter or number. Names such as <code>-test</code> are treated as literal because of the first character.
+Names are created automatically (POSIX style) if the given names start with a letter or number. Names such as <code>-test</code> or <code>/f</code> are treated as literal because of the first character.
 <!-- </tip> -->
 </td></tr></tbody></table><br>
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Lethargy: Terse & tiny command-line option library
 
-**Lethargy was born out of frustration**, like most of my projects. It gets out of your way as soon as possible to let you get on with the actual logic. No bullshit, no magic, no objects to understand, you just call a function.
+**Lethargy was born out of frustration**. It gets out of your way as soon as possible to let you get on with the actual logic. No bullshit, no magic, no objects to understand, you just call a function.
 
-I write a lot of small scripts to get my job done faster, and manually working with options is a pain. Existing libraries are extremely verbose or just don't feel good to use. _Lethargy is designed to make writing scripts easier and faster, and to reduce effort to maintain them_.
+I write a lot of small scripts to get my job done faster, and manually working with options is a pain. Existing libraries are extremely verbose or just don't feel good to use. _Lethargy is designed to make writing scripts easier and faster, and to reduce effort needed to maintain them_.
 
 <!-- Note that the spaces here are U+2000 (' ') EN QUAD -->
 <!--                 v                                  -->
@@ -34,7 +34,7 @@ with lethargy.show_errors():
     n_bytes = lethargy.take_opt('bytes', 1, int) or 8
 
 # Now the option and value have been removed from lethargy.argv
-with lethargy.expect(IndexError, reason="Missing required argument: [DIR]"):
+with lethargy.expect(IndexError, reason='Missing required argument: [DIR]'):
     directory = lethargy.argv[1]
 
 ...
@@ -84,7 +84,7 @@ True
 
 <table><tbody><tr><td>💡</td><td>
 <!-- <tip> -->
-Names are created automatically (POSIX style) if the given names start with a letter or number. Names such as <code>-test</code> or <code>/f</code> are treated as literal because of the first character.
+Names are created automatically (POSIX style) if the given names start with a letter or number. Names like <code>'-test'</code> or <code>'/f'</code> are treated as literal because of the first character.
 <!-- </tip> -->
 </td></tr></tbody></table><br>
 
@@ -167,7 +167,7 @@ Hi, None!
 
 ```python
 # -h|--set-hours <value> <value>
-start, finish = lethargy.take_opt(['set hours', 'h'], 2) or "9AM", "5PM"
+start, finish = lethargy.take_opt(['set hours', 'h'], 2) or '9AM', '5PM'
 
 print(f'Employee now works {start} to {finish}')
 ```
@@ -181,7 +181,7 @@ Employee works 8AM to 4PM
 
 <table><tbody><tr><td>💡</td><td>
 <!-- <tip> -->
-You should use defaults unless your option explicitly sets <code>required=True</code>. You'll thank yourself when you need to change something 6 months from now! 😉
+You should use defaults unless your option explicitly sets <code>required=True</code>. You'll thank yourself when you need to change something 6 months from now!
 <!-- </tip> -->
 </td></tr></tbody></table><br>
 
@@ -208,7 +208,7 @@ it has been 7500 days since 1999-10-09 00:00:00
 
 ###### ERROR HANDLING
 
-**Give clear error messages.** Lucky for you, lethargy's errors are extremely descriptive.
+**Give clear error messages.** Lethargy makes this easy with simple context managers.
 
 ```python
 with lethargy.show_errors():

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Option '-p|--pos <int> <int>' received an invalid value: '20,'
 <summary align="right">Learn more about handling errors</summary>
 <br>
 
-Use `fail()` to exit with status code 1. You can optionally use a message.
+Use `fail()` to exit with status code 1. You can optionally give it a message.
 
 Lethargy provides two context managers for easier error handling. These share similar behaviour, but are separate to make intent clearer.
 

--- a/README.md
+++ b/README.md
@@ -82,36 +82,11 @@ $ python example.py --verbose
 True
 ```
 
-<details>
-<summary align="right">Learn more about option names</summary>
-<br>
-
-Option names are automatically generated. `"use headers"` becomes `--use-headers`, and `"I"` becomes `-I`.
-
-If you provide an explicit name (starting with a non-alphanumeric character, such as `-`, `/` or `+`), the name is stripped and treated as literal.
-
-```python
-# -Enable
-enabled = lethargy.take_opt('-Enable')
-print(enabled)
-```
-
-```console
-$ python example.py -Enable
-True
-$ python example.py
-False
-```
-
-Names are _always_ case sensitive. `-Enable` **≠** `-enable`
-
-```console
-$ python example.py -enable
-False
-```
-
-<hr>
-</details>
+<table><tbody><tr><td>💡</td><td>
+<!-- <tip> -->
+Option names are created automatically (POSIX style) if the given names start with a letter or number. Names such as <code>-test</code> are treated as literal because of the first character.
+<!-- </tip> -->
+</td></tr></tbody></table><br>
 
 ###### ARGUMENTS
 
@@ -131,21 +106,11 @@ $ python example.py
 None
 ```
 
-<details>
-<summary align="right">Learn more about arguments</summary>
-<br>
-
-If there are fewer values for the option than the number given, `lethargy.ArgsError` will be raised. See [Error Handling](#error-handling) for how to present this nicely.
-
-```console
-$ python example.py --output
-Traceback (most recent call last):
-  [...]
-lethargy.errors.ArgsError: expected 1 argument for '-o|--output <value>', found none
-```
-
-<hr>
-</details>
+<table><tbody><tr><td>💡</td><td>
+<!-- <tip> -->
+If there are fewer values than what the option takes, it'll raise <code>lethargy.ArgsError</code>. See <a href="#error-handling">Error Handling</a> for how to present error messages nicely.
+<!-- </tip> -->
+</td></tr></tbody></table><br>
 
 ###### GREEDINESS
 
@@ -170,21 +135,11 @@ $ python example.py
 $ ▏
 ```
 
-<details>
-<summary align="right">Learn more about variadic options</summary>
-<br>
-
-Because variadic options will take every argument, including values that look like other options, you should try and take these last (_after_ taking the fixed-count options).
-
-```console
-$ python example.py --ignore "*.pyc" --exceptions some.pyc
-*.pyc
---exceptions
-some.pyc
-```
-
-<hr>
-</details>
+<table><tbody><tr><td>💡</td><td>
+<!-- <tip> -->
+Variadic options are greedy and will take <b>every</b> argument that follows them, including values that look like other options. You should always try and take these last (<i>after</i> taking the fixed-count options).
+<!-- </tip> -->
+</td></tr></tbody></table><br>
 
 ###### UNPACKING
 
@@ -224,7 +179,11 @@ $ python example.py --set-hours 8AM 4PM
 Employee works 8AM to 4PM
 ```
 
-<br>
+<table><tbody><tr><td>💡</td><td>
+<!-- <tip> -->
+You should use defaults unless your option explicitly sets <code>required=True</code>. You'll thank yourself when you need to change something 6 months from now! 😉
+<!-- </tip> -->
+</td></tr></tbody></table><br>
 
 ###### TYPES & CONVERSION
 
@@ -253,40 +212,37 @@ it has been 7500 days since 1999-10-09 00:00:00
 
 ```python
 with lethargy.show_errors():
-    n_bytes = lethargy.take_opt('bytes', 1, int) or 8
-    start, end = lethargy.take_opt(['r', 'range'], 2, int) or 0, 10
+    x, y = lethargy.take_opt(['p', 'pos'], 2, int) or 0, 0
 ```
 
 ```console
-$ python example.py --range 20
-Expected 2 arguments for option '-r|--range <int> <int>', but found 1 ('20')
-$ python example.py --bytes
-Expected 1 argument for option '--bytes <int>', but found none
-$ python example.py --bytes wrong
-Option '--bytes <int>' received an invalid value: 'wrong'
+$ python example.py --pos 20
+Expected 2 arguments for option '-p|--pos <int> <int>', but found 1 ('20')
+$ python example.py -p 20, 0
+Option '-p|--pos <int> <int>' received an invalid value: '20,'
 ```
 
 <details>
-<summary align="right">Learn more about error handling</summary>
+<summary align="right">Learn more about handling errors</summary>
 <br>
 
-Calling `fail()` will exit with status code 1. You can optionally use a message.
+Use `fail()` to exit with status code 1. You can optionally use a message.
 
 Lethargy provides two context managers for easier error handling. These share similar behaviour, but are separate to make intent clearer.
 
-> <i>with</i> <code><i>lethargy.</i><b>expect(</b><i>*errors: Exception</i>, <i>reason: Optional[str] = None</i><b>)</b></code>
+> <i>with</i> <code><i>lethargy.</i><b>expect(</b><i>*errors: Exception, reason: Optional[str] = None</i><b>)</b></code>
 
 When one of the given exceptions is raised, it calls `fail()` to exit and print the message.
 
 > <i>with</i> <code><i>lethargy.</i><b>show_errors()</b></code>
 
-Same behaviour as `expect`, but specifically for exceptions from lethargy.
+Same behaviour as `expect`, but specifically for handling options. Exceptions raised during value conversions will also be caught by `show_errors()`, with a useful message.
 
-Note that exceptions raised during value conversions will be caught by `show_errors()`.
-
-You can access the original exception that caused a `TransformError` with the `__cause__` attribute (see the Python [Built-in Exceptions] docs).
-
-[Built-in Exceptions]: https://docs.python.org/3/library/exceptions.html
+<table><tbody><tr><td>💡</td><td>
+<!-- <tip> -->
+You can access the original exception that caused a <code>TransformError</code> with the <code>__cause__</code> attribute (see the Python <a href="https://docs.python.org/3/library/exceptions.html">Built-in Exceptions</a> docs).
+<!-- </tip> -->
+</td></tr></tbody></table>
 
 <hr>
 </details>

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ True
 
 <table><tbody><tr><td>💡</td><td>
 <!-- <tip> -->
-Names are created automatically (POSIX style) if the given names start with a letter or number. Names like <code>'-test'</code> or <code>'/f'</code> are treated as literal because of the first character.
+Names are created automatically (POSIX style) if the given names start with a letter or number. Names like <code>'-test'</code> and <code>'/f'</code> are treated as literal because of the first character.
 <!-- </tip> -->
 </td></tr></tbody></table><br>
 
 ###### ARGUMENTS
 
-**Options can take arguments, too.** They can take any amount.
+**Options can take arguments, too.** They can take any amount, and values are **always** space-separated.
 
 ```python
 # -o|--output <value>

--- a/lethargy/__init__.py
+++ b/lethargy/__init__.py
@@ -1,7 +1,7 @@
 """Declarative, dynamic option parsing."""
 
 # fmt: off
-__version__ = "2.1.0"
+__version__ = "3.0.0"
 __all__ = (
     # Simplified interface
     # --------------------

--- a/lethargy/__init__.py
+++ b/lethargy/__init__.py
@@ -3,43 +3,26 @@
 # fmt: off
 __version__ = "3.0.0"
 __all__ = (
-    # Simplified interface
-    # --------------------
+    # Options & arguments
+    # -------------------
     "take_opt",
     "argv",
-    "expect",
+
+    # Error handling
+    # --------------
     "show_errors",
-
-    # Original interface
-    # ------------------
-    "Opt",
-
-    # Utility
-    # -------
-    "eprint",
+    "expect",
     "fail",
-    "print_if",
 
-    # Technical stuff
-    # ---------------
+    # Exceptions
+    # ----------
     "ArgsError",
     "MissingOption",
     "TransformError",
     "OptionError",
-
-    # Legacy
-    # ------
-    "take_debug",
-    "take_verbose",
 )
 # fmt: on
 
 from lethargy.errors import ArgsError, MissingOption, OptionError, TransformError
-from lethargy.option import Opt, take_opt
-from lethargy.util import argv, eprint, expect, fail, print_if, show_errors
-
-# The following options will be removed in version 3.0 because take_opt makes
-# them redundant. It's clearer and nearly as fast to use `take_opt('debug')`.
-
-take_debug = Opt("debug").take_flag
-take_verbose = Opt("v", "verbose").take_flag
+from lethargy.option import take_opt
+from lethargy.util import argv, expect, fail, show_errors

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -177,7 +177,7 @@ class Opt:
             # and TransformError. This allows manually handling specific
             # exception types, _and_ automatically handling all exceptions that
             # get raised during transformation.
-            name = f"TransformError<{exc.__class__.__name__}>"
+            name = f"TransformError[{exc.__class__.__name__}]"
             bases = (TransformError, exc.__class__)
             new_exc = type(name, bases, {})
 

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -107,7 +107,7 @@ class Opt:
 
         return True
 
-    def take_args(self, args=argv, *, raises=False, mut=True):
+    def take_args(self, args=argv, *, required=False, mut=True):
         """Get the values of this option."""
         argc = self.argc
 
@@ -124,7 +124,7 @@ class Opt:
 
         # Return early if the option isn't present.
         if index is None:
-            if raises:
+            if required:
                 msg = f"Missing required option '{self}'"
                 raise MissingOption(msg)
 
@@ -193,4 +193,4 @@ def take_opt(name, number=None, call=None, *, args=argv, required=False, mut=Tru
     opt = Opt(name, number, call)
     if not number:
         return opt.take_flag(args, mut=mut)
-    return opt.take_args(args, raises=required, mut=mut)
+    return opt.take_args(args, required=required, mut=mut)

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -1,7 +1,5 @@
 """Defines the Opt class (main interface)."""
 
-from copy import copy
-
 from lethargy.errors import ArgsError, MissingOption, TransformError
 from lethargy.util import argv, falsylist, identity, is_greedy, stab
 
@@ -13,9 +11,6 @@ class Option:
         self.names = set(map(stab, [name] if isinstance(name, str) else name))
         self.argc = number  # Invalid values are handled by the setter.
         self.tfm = tfm or identity
-
-    def __copy__(self):
-        return type(self)(copy(self.names), self.argc, self.tfm)
 
     def __str__(self):
         if not self.names:
@@ -62,16 +57,6 @@ class Option:
         repr_str += f" at {hex(id(self))}"
 
         return f"<{repr_str}>"
-
-    def __eq__(self, other):
-        try:
-            return (
-                self.names == other.names
-                and self.argc == other.argc
-                and self.tfm is other.tfm
-            )
-        except AttributeError:
-            return NotImplemented
 
     @property
     def argc(self):

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -76,7 +76,7 @@ class Opt:
 
     @property
     def argc(self):
-        """Get the number of arguments"""
+        """Get the number of arguments this option takes."""
         return self._argc
 
     @argc.setter
@@ -111,13 +111,9 @@ class Opt:
         """Get the values of this option."""
         argc = self.argc
 
-        # Taking less than 1 argument will do nothing, use take_flag instead.
-        # Assume argc is numeric if it's not greedy.
-        if not is_greedy(argc) and argc < 1:
-            s = "s" if argc != 1 else ""
-            n = "no" if argc == 0 else argc
-            msg = f"'{self}' takes {n} argument{s} (did you mean to use `take_flag`?)"
-            raise ArgsError(msg)
+        if not argc:
+            msg = f"'{self}' takes no arguments (did you mean to use `take_flag`?)"
+            raise RuntimeError(msg)
 
         # Is this option in the list?
         index = self.find_in(args)

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -179,10 +179,10 @@ class Opt:
 
             # The exception needs to be a subclass of both the raised exception
             # and TransformError. This allows manually handling specific
-            # exception types, _and_ automatically handling any exceptions that
+            # exception types, _and_ automatically handling all exceptions that
             # get raised during transformation.
-            name = f"<TransformError | {exc.__class__.__name__}>"
-            bases = (exc.__class__, TransformError)
+            name = f"TransformError<{exc.__class__.__name__}>"
+            bases = (TransformError, exc.__class__)
             new_exc = type(name, bases, {})
 
             raise new_exc(message) from exc

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -97,13 +97,13 @@ class Opt:
 
     def take_flag(self, args=argv, *, mut=True):
         """Get a bool indicating whether the option was present in the arguments."""
-        idx = self.find_in(args)
+        index = self.find_in(args)
 
-        if idx is None:
+        if index is None:
             return False
 
         if mut:
-            del args[idx]
+            del args[index]
 
         return True
 

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -1,14 +1,14 @@
 """Defines the Opt class (main interface)."""
 
 from lethargy.errors import ArgsError, MissingOption, TransformError
-from lethargy.util import argv, falsylist, identity, is_greedy, stab
+from lethargy.util import argv, falsylist, identity, is_greedy, tryposixname
 
 
 class Option:
     """Define an option to take it from a list of arguments."""
 
     def __init__(self, name, number=0, tfm=None):
-        self.names = set(map(stab, [name] if isinstance(name, str) else name))
+        self.names = set(map(tryposixname, [name] if isinstance(name, str) else name))
         self.argc = number  # Invalid values are handled by the setter.
         self.tfm = tfm or identity
 
@@ -118,7 +118,7 @@ class Option:
 
         # Start index is now set, find the index of the *final* value.
         if is_greedy(argc):
-            end_idx = len(args)
+            end_idx = None
         else:
             # Start index is the option name, add 1 to compensate.
             end_idx = index + argc + 1
@@ -169,7 +169,7 @@ class Option:
 
 
 def take_opt(name, number=None, call=None, *, args=argv, required=False, mut=True):
-    """Quickly take an option as flag, or with some arguments."""
+    """Quickly take an option as flag, or with some arguments if also given a number."""
     if not number:
         return Option(name).take_flag(args, mut=mut)
 

--- a/lethargy/option.py
+++ b/lethargy/option.py
@@ -110,7 +110,7 @@ class Opt:
 
         return True
 
-    def take_args(self, args=argv, *, raises=False, mut=True, d=None):
+    def take_args(self, args=argv, *, raises=False, mut=True):
         """Get the values of this option."""
         argc = self._argc
 
@@ -132,14 +132,12 @@ class Opt:
                 raise MissingOption(msg)
 
             if is_greedy(argc):
-                return falsylist() if d is None else d
+                return falsylist()
 
-            if d is None and argc != 1:
+            if argc != 1:
                 return falsylist([None] * argc)
 
-            # `if d is None and argc == 1` should return None anyway. As long
-            # as d is None by default then this always returns correctly.
-            return d
+            return None
 
         # Start index is now set, find the index of the *final* value.
         if is_greedy(argc):

--- a/lethargy/util.py
+++ b/lethargy/util.py
@@ -1,7 +1,7 @@
 """Functions and values, independent of other modules."""
 
-import contextlib
 import sys
+from contextlib import contextmanager
 
 from lethargy.errors import OptionError, TransformError
 
@@ -10,25 +10,8 @@ from lethargy.errors import OptionError, TransformError
 argv = sys.argv.copy()
 
 
-def stab(text):
-    """Stab a string, with a skewer of appropriate length.
-
-        >>> stab('x')
-        '-x'
-        >>> stab('xyz')
-        '--xyz'
-        >>> stab('abc xyz')
-        '--abc-xyz'
-        >>> stab('  lm no p ')
-        '--lm-no-p'
-
-    Unless the string starts with something that isn't a letter or number.
-
-        >>> stab('  -x')
-        '-x'
-        >>> stab('/FLAG ')
-        '/FLAG'
-    """
+def tryposixname(text):
+    """Get a POSIX-style name, or strip if the first character isn't alphanumeric."""
     stripped = str(text).strip()
 
     # Assume it's been pre-formatted if it starts with something that's not
@@ -45,7 +28,7 @@ def stab(text):
     if chars == 1:
         return f"-{name}"
 
-    raise ValueError("Cannot stab an empty string.")
+    raise ValueError("Cannot make an option name from an empty string.")
 
 
 def is_greedy(value):
@@ -65,7 +48,7 @@ def fail(message=None):
     sys.exit(1)
 
 
-@contextlib.contextmanager
+@contextmanager
 def expect(*errors, reason=None):
     """Call `fail()` if any given errors are raised."""
     try:
@@ -74,6 +57,9 @@ def expect(*errors, reason=None):
         fail(reason or e)
 
 
-show_errors = lambda: expect(OptionError, TransformError)
+def show_errors():
+    """Expect errors from options and values, fail with a useful message."""
+    return expect(OptionError, TransformError)
+
 
 falsylist = type("falsylist", (list,), {"__bool__": lambda _: False})

--- a/lethargy/util.py
+++ b/lethargy/util.py
@@ -1,7 +1,6 @@
 """Functions and values, independent of other modules."""
 
 import contextlib
-import functools
 import sys
 
 from lethargy.errors import OptionError, TransformError
@@ -59,11 +58,6 @@ def identity(a):
     return a
 
 
-def print_if(condition):
-    """Return either ``print`` or a dummy function, depending on ``condition``."""
-    return print if condition else lambda *__, **_: None
-
-
 def fail(message=None):
     """Print a message to stderr and exit with code 1."""
     if message:
@@ -81,7 +75,5 @@ def expect(*errors, reason=None):
 
 
 show_errors = lambda: expect(OptionError, TransformError)
-
-eprint = functools.partial(print, file=sys.stderr)
 
 falsylist = type("falsylist", (list,), {"__bool__": lambda _: False})

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,458 @@
+[[package]]
+category = "dev"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+name = "appdirs"
+optional = false
+python-versions = "*"
+version = "1.4.3"
+
+[[package]]
+category = "dev"
+description = "An abstract syntax tree for Python with inference support."
+name = "astroid"
+optional = false
+python-versions = ">=3.5.*"
+version = "2.3.3"
+
+[package.dependencies]
+lazy-object-proxy = ">=1.4.0,<1.5.0"
+six = ">=1.12,<2.0"
+wrapt = ">=1.11.0,<1.12.0"
+
+[package.dependencies.typed-ast]
+python = "<3.8"
+version = ">=1.4.0,<1.5"
+
+[[package]]
+category = "dev"
+description = "Atomic file writes."
+marker = "sys_platform == \"win32\""
+name = "atomicwrites"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.3.0"
+
+[[package]]
+category = "dev"
+description = "Classes Without Boilerplate"
+name = "attrs"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "19.3.0"
+
+[package.extras]
+azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
+dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
+docs = ["sphinx", "zope.interface"]
+tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+
+[[package]]
+category = "dev"
+description = "The uncompromising code formatter."
+name = "black"
+optional = false
+python-versions = ">=3.6"
+version = "19.10b0"
+
+[package.dependencies]
+appdirs = "*"
+attrs = ">=18.1.0"
+click = ">=6.5"
+pathspec = ">=0.6,<1"
+regex = "*"
+toml = ">=0.9.4"
+typed-ast = ">=1.4.0"
+
+[package.extras]
+d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+
+[[package]]
+category = "dev"
+description = "Composable command line interface toolkit"
+name = "click"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.1"
+
+[[package]]
+category = "dev"
+description = "Cross-platform colored terminal text."
+marker = "sys_platform == \"win32\""
+name = "colorama"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.3"
+
+[[package]]
+category = "dev"
+description = "Read metadata from Python packages"
+marker = "python_version < \"3.8\""
+name = "importlib-metadata"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.6.0"
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "rst.linker"]
+testing = ["packaging", "importlib-resources"]
+
+[[package]]
+category = "dev"
+description = "A Python utility / library to sort Python imports."
+name = "isort"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "4.3.21"
+
+[package.extras]
+pipfile = ["pipreqs", "requirementslib"]
+pyproject = ["toml"]
+requirements = ["pipreqs", "pip-api"]
+xdg_home = ["appdirs (>=1.4.0)"]
+
+[[package]]
+category = "dev"
+description = "A fast and thorough lazy object proxy."
+name = "lazy-object-proxy"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.4.3"
+
+[[package]]
+category = "dev"
+description = "McCabe checker, plugin for flake8"
+name = "mccabe"
+optional = false
+python-versions = "*"
+version = "0.6.1"
+
+[[package]]
+category = "dev"
+description = "More routines for operating on iterables, beyond itertools"
+name = "more-itertools"
+optional = false
+python-versions = ">=3.5"
+version = "8.2.0"
+
+[[package]]
+category = "dev"
+description = "Core utilities for Python packages"
+name = "packaging"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "20.3"
+
+[package.dependencies]
+pyparsing = ">=2.0.2"
+six = "*"
+
+[[package]]
+category = "dev"
+description = "Utility library for gitignore style pattern matching of file paths."
+name = "pathspec"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.8.0"
+
+[[package]]
+category = "dev"
+description = "plugin and hook calling mechanisms for python"
+name = "pluggy"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.13.1"
+
+[package.dependencies]
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+
+[[package]]
+category = "dev"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+name = "py"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.8.1"
+
+[[package]]
+category = "dev"
+description = "python code static checker"
+name = "pylint"
+optional = false
+python-versions = ">=3.5.*"
+version = "2.4.4"
+
+[package.dependencies]
+astroid = ">=2.3.0,<2.4"
+colorama = "*"
+isort = ">=4.2.5,<5"
+mccabe = ">=0.6,<0.7"
+
+[[package]]
+category = "dev"
+description = "Python parsing module"
+name = "pyparsing"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.4.7"
+
+[[package]]
+category = "dev"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
+optional = false
+python-versions = ">=3.5"
+version = "5.4.1"
+
+[package.dependencies]
+atomicwrites = ">=1.0"
+attrs = ">=17.4.0"
+colorama = "*"
+more-itertools = ">=4.0.0"
+packaging = "*"
+pluggy = ">=0.12,<1.0"
+py = ">=1.5.0"
+wcwidth = "*"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
+[package.extras]
+checkqa-mypy = ["mypy (v0.761)"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+category = "dev"
+description = "Alternative regular expression module, to replace re."
+name = "regex"
+optional = false
+python-versions = "*"
+version = "2020.4.4"
+
+[[package]]
+category = "dev"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "1.14.0"
+
+[[package]]
+category = "dev"
+description = "Python Library for Tom's Obvious, Minimal Language"
+name = "toml"
+optional = false
+python-versions = "*"
+version = "0.10.0"
+
+[[package]]
+category = "dev"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+name = "typed-ast"
+optional = false
+python-versions = "*"
+version = "1.4.1"
+
+[[package]]
+category = "dev"
+description = "Measures number of Terminal column cells of wide-character codes"
+name = "wcwidth"
+optional = false
+python-versions = "*"
+version = "0.1.9"
+
+[[package]]
+category = "dev"
+description = "Module for decorators, wrappers and monkey patching."
+name = "wrapt"
+optional = false
+python-versions = "*"
+version = "1.11.2"
+
+[[package]]
+category = "dev"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+marker = "python_version < \"3.8\""
+name = "zipp"
+optional = false
+python-versions = ">=3.6"
+version = "3.1.0"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["jaraco.itertools", "func-timeout"]
+
+[metadata]
+content-hash = "96ad4ab75d454ecf0414e7a95651a28ede19fb7837782ad65c80384beace3ff8"
+python-versions = "^3.6"
+
+[metadata.files]
+appdirs = [
+    {file = "appdirs-1.4.3-py2.py3-none-any.whl", hash = "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"},
+    {file = "appdirs-1.4.3.tar.gz", hash = "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92"},
+]
+astroid = [
+    {file = "astroid-2.3.3-py3-none-any.whl", hash = "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"},
+    {file = "astroid-2.3.3.tar.gz", hash = "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.3.0-py2.py3-none-any.whl", hash = "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4"},
+    {file = "atomicwrites-1.3.0.tar.gz", hash = "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"},
+]
+attrs = [
+    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
+    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
+]
+black = [
+    {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
+    {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
+]
+click = [
+    {file = "click-7.1.1-py2.py3-none-any.whl", hash = "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"},
+    {file = "click-7.1.1.tar.gz", hash = "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc"},
+]
+colorama = [
+    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
+    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
+    {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
+]
+isort = [
+    {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
+    {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
+]
+lazy-object-proxy = [
+    {file = "lazy-object-proxy-1.4.3.tar.gz", hash = "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"},
+    {file = "lazy_object_proxy-1.4.3-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442"},
+    {file = "lazy_object_proxy-1.4.3-cp27-cp27m-win32.whl", hash = "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4"},
+    {file = "lazy_object_proxy-1.4.3-cp27-cp27m-win_amd64.whl", hash = "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a"},
+    {file = "lazy_object_proxy-1.4.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d"},
+    {file = "lazy_object_proxy-1.4.3-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a"},
+    {file = "lazy_object_proxy-1.4.3-cp34-cp34m-win32.whl", hash = "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e"},
+    {file = "lazy_object_proxy-1.4.3-cp34-cp34m-win_amd64.whl", hash = "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357"},
+    {file = "lazy_object_proxy-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50"},
+    {file = "lazy_object_proxy-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db"},
+    {file = "lazy_object_proxy-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449"},
+    {file = "lazy_object_proxy-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156"},
+    {file = "lazy_object_proxy-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531"},
+    {file = "lazy_object_proxy-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb"},
+    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08"},
+    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383"},
+    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142"},
+    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea"},
+    {file = "lazy_object_proxy-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62"},
+    {file = "lazy_object_proxy-1.4.3-cp38-cp38-win32.whl", hash = "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd"},
+    {file = "lazy_object_proxy-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+more-itertools = [
+    {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},
+    {file = "more_itertools-8.2.0-py3-none-any.whl", hash = "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c"},
+]
+packaging = [
+    {file = "packaging-20.3-py2.py3-none-any.whl", hash = "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"},
+    {file = "packaging-20.3.tar.gz", hash = "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3"},
+]
+pathspec = [
+    {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
+    {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+py = [
+    {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
+    {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
+]
+pylint = [
+    {file = "pylint-2.4.4-py3-none-any.whl", hash = "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"},
+    {file = "pylint-2.4.4.tar.gz", hash = "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+]
+pytest = [
+    {file = "pytest-5.4.1-py3-none-any.whl", hash = "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172"},
+    {file = "pytest-5.4.1.tar.gz", hash = "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"},
+]
+regex = [
+    {file = "regex-2020.4.4-cp27-cp27m-win32.whl", hash = "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f"},
+    {file = "regex-2020.4.4-cp27-cp27m-win_amd64.whl", hash = "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3"},
+    {file = "regex-2020.4.4-cp36-cp36m-win32.whl", hash = "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8"},
+    {file = "regex-2020.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948"},
+    {file = "regex-2020.4.4-cp37-cp37m-win32.whl", hash = "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e"},
+    {file = "regex-2020.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"},
+    {file = "regex-2020.4.4-cp38-cp38-win32.whl", hash = "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3"},
+    {file = "regex-2020.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3"},
+    {file = "regex-2020.4.4.tar.gz", hash = "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142"},
+]
+six = [
+    {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},
+    {file = "six-1.14.0.tar.gz", hash = "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"},
+]
+toml = [
+    {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},
+    {file = "toml-0.10.0-py2.py3-none-any.whl", hash = "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"},
+    {file = "toml-0.10.0.tar.gz", hash = "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
+    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
+    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+]
+wcwidth = [
+    {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},
+    {file = "wcwidth-0.1.9.tar.gz", hash = "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"},
+]
+wrapt = [
+    {file = "wrapt-1.11.2.tar.gz", hash = "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"},
+]
+zipp = [
+    {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},
+    {file = "zipp-3.1.0.tar.gz", hash = "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lethargy"
-version = "2.1.0"
+version = "3.0.0"
 description = "A minimal library to make your option-parsing easier."
 license = "MIT"
 repository = "https://github.com/SeparateRecords/lethargy"

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -4,8 +4,6 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=protected-access
 
-from copy import copy
-
 import pytest
 
 import lethargy
@@ -115,7 +113,7 @@ def test_take_args_not_found_raises_true_raises_missingoption(args, amt):
 @pytest.mark.parametrize("amt", (1, 2, 3, ...))
 def test_take_args_no_mut(amt):
     in_args = [0, "-x", 0, 0, 0, 0]
-    out_args = copy(in_args)
+    out_args = in_args.copy()
 
     Option("x", amt).take_args(in_args, mut=False)
     assert in_args == out_args
@@ -123,7 +121,7 @@ def test_take_args_no_mut(amt):
 
 def test_take_flag_no_mut():
     in_args = [0, "-x", 0]
-    out_args = copy(in_args)
+    out_args = in_args.copy()
 
     Option("x").take_flag(in_args, mut=False)
     assert in_args == out_args
@@ -136,24 +134,6 @@ def test_find_in():
     args_2 = [0, 1, 2, "--aa", 4]
     assert o.find_in(args_1) == 2
     assert o.find_in(args_2) == 3
-
-
-def test_copy():
-    original = Option("test", 1)
-    copied = original.__copy__()
-    assert original is not copied
-    assert original == copied
-
-
-def test_eq():
-    assert Option([], 1) == Option([], 1)
-    assert Option("test", 1) != Option([], 1)
-
-    assert Option([], 1) == Option([], 1)
-    assert Option([], 2) != Option([], 1)
-
-    assert Option([], 1, int) == Option([], 1, int)
-    assert Option([], 1, int) != Option([], 1)
 
 
 def test_converter_single_value():

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -109,7 +109,7 @@ def test_take_args_not_found_return_value_is_falsy(args, amt):
 @pytest.mark.parametrize("amt", (1, 2, ...))
 def test_take_args_not_found_raises_true_raises_missingoption(args, amt):
     with pytest.raises(lethargy.MissingOption):
-        assert Opt("w", amt).take_args(args, raises=True)
+        assert Opt("w", amt).take_args(args, required=True)
 
 
 @pytest.mark.parametrize("amt", (1, 2, 3, ...))

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -9,7 +9,7 @@ from copy import copy
 import pytest
 
 import lethargy
-from lethargy.option import Opt
+from lethargy.option import Option
 
 
 def all_args():
@@ -25,21 +25,21 @@ def args():
     "option, string",
     [
         # Flags
-        (Opt("x"), "-x"),
-        (Opt("mul"), "--mul"),
-        (Opt(["mul", "x"]), "-x|--mul"),
+        (Option("x"), "-x"),
+        (Option("mul"), "--mul"),
+        (Option(["mul", "x"]), "-x|--mul"),
         # Options with arguments
-        (Opt("x", 1), "-x <value>"),
-        (Opt("mul", 1), "--mul <value>"),
-        (Opt(["mul", "x"], 1), "-x|--mul <value>"),
-        (Opt(["mul", "x"], 1, int), "-x|--mul <int>"),
-        (Opt(["mul", "x"], 1, lambda x: x), "-x|--mul <value>"),
+        (Option("x", 1), "-x <value>"),
+        (Option("mul", 1), "--mul <value>"),
+        (Option(["mul", "x"], 1), "-x|--mul <value>"),
+        (Option(["mul", "x"], 1, int), "-x|--mul <int>"),
+        (Option(["mul", "x"], 1, lambda x: x), "-x|--mul <value>"),
         # Greedy options
-        (Opt("x", ...), "-x [value]..."),
-        (Opt("mul", ...), "--mul [value]..."),
-        (Opt(["mul", "x"], ...), "-x|--mul [value]..."),
-        (Opt(["mul", "x"], ..., int), "-x|--mul [int]..."),
-        (Opt(["mul", "x"], ..., lambda x: x), "-x|--mul [value]..."),
+        (Option("x", ...), "-x [value]..."),
+        (Option("mul", ...), "--mul [value]..."),
+        (Option(["mul", "x"], ...), "-x|--mul [value]..."),
+        (Option(["mul", "x"], ..., int), "-x|--mul [int]..."),
+        (Option(["mul", "x"], ..., lambda x: x), "-x|--mul [value]..."),
     ],
 )
 def test_string_form(option, string):
@@ -47,69 +47,69 @@ def test_string_form(option, string):
 
 
 def test_take_flag(args):
-    assert Opt("a").take_flag(args) is True
-    assert Opt("w").take_flag(args) is False
+    assert Option("a").take_flag(args) is True
+    assert Option("w").take_flag(args) is False
 
 
 def test_take_args_less_than_1_raises_err(args):
     with pytest.raises(RuntimeError):
-        Opt("a").take_args(args)
+        Option("a").take_args(args)
 
 
 def test_argc_cannot_be_set_below_0():
     with pytest.raises(ValueError):
-        Opt("a", -1)
+        Option("a", -1)
 
 
 def test_take_args_1_returns_single_value(args):
-    assert Opt("a", 1).take_args(args) == "b"
+    assert Option("a", 1).take_args(args) == "b"
     assert args == ["c", "-d", "e", "--fgh", "i", "j", "-xyz"]
 
 
 def test_take_args_2_or_more_returns_list(args):
-    assert Opt("a", 2).take_args(args) == ["b", "c"]
+    assert Option("a", 2).take_args(args) == ["b", "c"]
     assert args == ["-d", "e", "--fgh", "i", "j", "-xyz"]
 
 
 def test_take_args_valid_but_no_args_found_after_option():
     args = ["a", "b", "-c"]
     with pytest.raises(lethargy.ArgsError):
-        Opt("c", 1).take_args(args)
+        Option("c", 1).take_args(args)
     assert args == ["a", "b", "-c"]
 
 
 def test_take_args_greedy_returns_everything(args):
     expected = ["b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
-    assert Opt("a", ...).take_args(args) == expected
+    assert Option("a", ...).take_args(args) == expected
     assert args == []
 
 
 # opt not found, default none, raises false
 def test_take_args_not_found_1_arg_returns_single_none(args):
-    assert Opt("w", 1).take_args(args) is None
+    assert Option("w", 1).take_args(args) is None
     assert args == all_args()
 
 
 def test_take_args_not_found_2_or_more_returns_none_list(args):
-    assert Opt("w", 2).take_args(args) == [None, None]
+    assert Option("w", 2).take_args(args) == [None, None]
     assert args == all_args()
 
 
 def test_take_args_not_found_greedy_returns_empty_list(args):
-    assert Opt("w", ...).take_args(args) == []
+    assert Option("w", ...).take_args(args) == []
     assert args == all_args()
 
 
 @pytest.mark.parametrize("amt", (2, ...))
 def test_take_args_not_found_return_value_is_falsy(args, amt):
-    assert not Opt("w", amt).take_args(args)
+    assert not Option("w", amt).take_args(args)
 
 
 # opt not found, default not none, raises true
 @pytest.mark.parametrize("amt", (1, 2, ...))
 def test_take_args_not_found_raises_true_raises_missingoption(args, amt):
     with pytest.raises(lethargy.MissingOption):
-        assert Opt("w", amt).take_args(args, required=True)
+        assert Option("w", amt).take_args(args, required=True)
 
 
 @pytest.mark.parametrize("amt", (1, 2, 3, ...))
@@ -117,7 +117,7 @@ def test_take_args_no_mut(amt):
     in_args = [0, "-x", 0, 0, 0, 0]
     out_args = copy(in_args)
 
-    Opt("x", amt).take_args(in_args, mut=False)
+    Option("x", amt).take_args(in_args, mut=False)
     assert in_args == out_args
 
 
@@ -125,13 +125,13 @@ def test_take_flag_no_mut():
     in_args = [0, "-x", 0]
     out_args = copy(in_args)
 
-    Opt("x").take_flag(in_args, mut=False)
+    Option("x").take_flag(in_args, mut=False)
     assert in_args == out_args
 
 
 def test_find_in():
     # should find either -a or --aa
-    o = Opt(["a", "aa"])
+    o = Option(["a", "aa"])
     args_1 = [0, 1, "-a", 3, 4]
     args_2 = [0, 1, 2, "--aa", 4]
     assert o.find_in(args_1) == 2
@@ -139,29 +139,29 @@ def test_find_in():
 
 
 def test_copy():
-    original = Opt("test", 1)
+    original = Option("test", 1)
     copied = original.__copy__()
     assert original is not copied
     assert original == copied
 
 
 def test_eq():
-    assert Opt([], 1) == Opt([], 1)
-    assert Opt("test", 1) != Opt([], 1)
+    assert Option([], 1) == Option([], 1)
+    assert Option("test", 1) != Option([], 1)
 
-    assert Opt([], 1) == Opt([], 1)
-    assert Opt([], 2) != Opt([], 1)
+    assert Option([], 1) == Option([], 1)
+    assert Option([], 2) != Option([], 1)
 
-    assert Opt([], 1, int) == Opt([], 1, int)
-    assert Opt([], 1, int) != Opt([], 1)
+    assert Option([], 1, int) == Option([], 1, int)
+    assert Option([], 1, int) != Option([], 1)
 
 
 def test_converter_single_value():
-    a = Opt("test", 1, int).take_args(["--test", "0"])
+    a = Option("test", 1, int).take_args(["--test", "0"])
     assert isinstance(a, int)
 
 
-@pytest.mark.parametrize("opt", (Opt("test", 2, int), Opt("test", ..., int)))
+@pytest.mark.parametrize("opt", (Option("test", 2, int), Option("test", ..., int)))
 def test_converter_multiple_values(opt):
     values = opt.take_args(["--test", "0", "1", "2", "3"])
     for val in values:
@@ -175,7 +175,7 @@ def test_transform_calls_tfm_function_with_value():
         def tfm(self, value):
             return value
 
-    assert Opt.transform(TfmOpt(), expected) is expected
+    assert Option.transform(TfmOpt(), expected) is expected
 
 
 def test_transform_raises_exception_with_correct_exception():
@@ -187,7 +187,7 @@ def test_transform_raises_exception_with_correct_exception():
             raise CustomException
 
     with pytest.raises(CustomException):
-        Opt.transform(TfmOpt(), "")
+        Option.transform(TfmOpt(), "")
 
     with pytest.raises(lethargy.TransformError):
-        Opt.transform(TfmOpt(), "")
+        Option.transform(TfmOpt(), "")

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -9,7 +9,7 @@ from copy import copy
 import pytest
 
 import lethargy
-from lethargy import Opt
+from lethargy.option import Opt
 
 
 def all_args():
@@ -27,19 +27,19 @@ def args():
         # Flags
         (Opt("x"), "-x"),
         (Opt("mul"), "--mul"),
-        (Opt("mul", "x"), "-x|--mul"),
+        (Opt(["mul", "x"]), "-x|--mul"),
         # Options with arguments
-        (Opt("x").takes(1), "-x <value>"),
-        (Opt("mul").takes(1), "--mul <value>"),
-        (Opt("mul", "x").takes(1), "-x|--mul <value>"),
-        (Opt("mul", "x").takes(1, int), "-x|--mul <int>"),
-        (Opt("mul", "x").takes(1, lambda x: x), "-x|--mul <value>"),
+        (Opt("x", 1), "-x <value>"),
+        (Opt("mul", 1), "--mul <value>"),
+        (Opt(["mul", "x"], 1), "-x|--mul <value>"),
+        (Opt(["mul", "x"], 1, int), "-x|--mul <int>"),
+        (Opt(["mul", "x"], 1, lambda x: x), "-x|--mul <value>"),
         # Greedy options
-        (Opt("x").takes(...), "-x [value]..."),
-        (Opt("mul").takes(...), "--mul [value]..."),
-        (Opt("mul", "x").takes(...), "-x|--mul [value]..."),
-        (Opt("mul", "x").takes(..., int), "-x|--mul [int]..."),
-        (Opt("mul", "x").takes(..., lambda x: x), "-x|--mul [value]..."),
+        (Opt("x", ...), "-x [value]..."),
+        (Opt("mul", ...), "--mul [value]..."),
+        (Opt(["mul", "x"], ...), "-x|--mul [value]..."),
+        (Opt(["mul", "x"], ..., int), "-x|--mul [int]..."),
+        (Opt(["mul", "x"], ..., lambda x: x), "-x|--mul [value]..."),
     ],
 )
 def test_string_form(option, string):
@@ -62,60 +62,54 @@ def test_take_args_less_than_1_raises_err(args):
 
 
 def test_take_args_1_returns_single_value(args):
-    assert Opt("a").takes(1).take_args(args) == "b"
+    assert Opt("a", 1).take_args(args) == "b"
     assert args == ["c", "-d", "e", "--fgh", "i", "j", "-xyz"]
 
 
 def test_take_args_2_or_more_returns_list(args):
-    assert Opt("a").takes(2).take_args(args) == ["b", "c"]
+    assert Opt("a", 2).take_args(args) == ["b", "c"]
     assert args == ["-d", "e", "--fgh", "i", "j", "-xyz"]
 
 
 def test_take_args_valid_but_no_args_found_after_option():
     args = ["a", "b", "-c"]
     with pytest.raises(lethargy.ArgsError):
-        Opt("c").takes(1).take_args(args)
+        Opt("c", 1).take_args(args)
     assert args == ["a", "b", "-c"]
 
 
 def test_take_args_greedy_returns_everything(args):
     expected = ["b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
-    assert Opt("a").takes(...).take_args(args) == expected
+    assert Opt("a", ...).take_args(args) == expected
     assert args == []
 
 
 # opt not found, default none, raises false
-def test_take_args_not_found_default_none_1_arg_returns_single_none(args):
-    assert Opt("w").takes(1).take_args(args) is None
+def test_take_args_not_found_1_arg_returns_single_none(args):
+    assert Opt("w", 1).take_args(args) is None
     assert args == all_args()
 
 
-def test_take_args_not_found_default_none_2_or_more_returns_none_list(args):
-    assert Opt("w").takes(2).take_args(args) == [None, None]
+def test_take_args_not_found_2_or_more_returns_none_list(args):
+    assert Opt("w", 2).take_args(args) == [None, None]
     assert args == all_args()
 
 
-def test_take_args_not_found_default_none_greedy_returns_empty_list(args):
-    assert Opt("w").takes(...).take_args(args) == []
+def test_take_args_not_found_greedy_returns_empty_list(args):
+    assert Opt("w", ...).take_args(args) == []
     assert args == all_args()
 
 
 @pytest.mark.parametrize("amt", (2, ...))
-def test_take_args_not_found_default_none_return_value_is_falsy(args, amt):
-    assert not Opt("w").takes(amt).take_args(args)
-
-
-# opt not found, default not none, raises false
-@pytest.mark.parametrize("amt", (1, 2, ...))
-def test_take_args_not_found_default_not_none_returns_default(args, amt):
-    assert Opt("w").takes(amt).take_args(args, d=1) == 1
+def test_take_args_not_found_return_value_is_falsy(args, amt):
+    assert not Opt("w", amt).take_args(args)
 
 
 # opt not found, default not none, raises true
 @pytest.mark.parametrize("amt", (1, 2, ...))
 def test_take_args_not_found_raises_true_raises_missingoption(args, amt):
     with pytest.raises(lethargy.MissingOption):
-        assert Opt("w").takes(amt).take_args(args, raises=True)
+        assert Opt("w", amt).take_args(args, raises=True)
 
 
 @pytest.mark.parametrize("amt", (1, 2, 3, ...))
@@ -123,7 +117,7 @@ def test_take_args_no_mut(amt):
     in_args = [0, "-x", 0, 0, 0, 0]
     out_args = copy(in_args)
 
-    Opt("x").takes(amt).take_args(in_args, mut=False)
+    Opt("x", amt).take_args(in_args, mut=False)
     assert in_args == out_args
 
 
@@ -137,46 +131,37 @@ def test_take_flag_no_mut():
 
 def test_find_in():
     # should find either -a or --aa
-    o = Opt("a", "aa")
+    o = Opt(["a", "aa"])
     args_1 = [0, 1, "-a", 3, 4]
     args_2 = [0, 1, 2, "--aa", 4]
-    assert o._find_in(args_1) == 2
-    assert o._find_in(args_2) == 3
-
-
-def test_takes():
-    o = Opt()
-    assert o._argc == 0
-    assert o.takes(1) is o
-    assert o._argc == 1
+    assert o.find_in(args_1) == 2
+    assert o.find_in(args_2) == 3
 
 
 def test_copy():
-    original = Opt("test").takes(1)
+    original = Opt("test", 1)
     copied = original.__copy__()
     assert original is not copied
     assert original == copied
 
 
 def test_eq():
-    assert Opt().takes(1) == Opt().takes(1)
-    assert Opt("test").takes(1) != Opt().takes(1)
+    assert Opt([], 1) == Opt([], 1)
+    assert Opt("test", 1) != Opt([], 1)
 
-    assert Opt().takes(1) == Opt().takes(1)
-    assert Opt().takes(2) != Opt().takes(1)
+    assert Opt([], 1) == Opt([], 1)
+    assert Opt([], 2) != Opt([], 1)
 
-    assert Opt().takes(1, int) == Opt().takes(1, int)
-    assert Opt().takes(1, int) != Opt().takes(1)
+    assert Opt([], 1, int) == Opt([], 1, int)
+    assert Opt([], 1, int) != Opt([], 1)
 
 
 def test_converter_single_value():
-    a = Opt("test").takes(1, int).take_args(["--test", "0"])
+    a = Opt("test", 1, int).take_args(["--test", "0"])
     assert isinstance(a, int)
 
 
-@pytest.mark.parametrize(
-    "opt", (Opt("test").takes(2, int), Opt("test").takes(..., int))
-)
+@pytest.mark.parametrize("opt", (Opt("test", 2, int), Opt("test", ..., int)))
 def test_converter_multiple_values(opt):
     values = opt.take_args(["--test", "0", "1", "2", "3"])
     for val in values:
@@ -187,10 +172,10 @@ def test_transform_calls_tfm_function_with_value():
     expected = []
 
     class MockOpt:
-        def _tfm(self, value):
+        def tfm(self, value):
             return value
 
-    assert Opt._transform(MockOpt(), expected) is expected
+    assert Opt.transform(MockOpt(), expected) is expected
 
 
 def test_transform_raises_exception_with_correct_exception():
@@ -198,11 +183,11 @@ def test_transform_raises_exception_with_correct_exception():
         pass
 
     class MockOpt:
-        def _tfm(self, _):
+        def tfm(self, _):
             raise CustomException
 
     with pytest.raises(CustomException):
-        Opt._transform(MockOpt(), "")
+        Opt.transform(MockOpt(), "")
 
     with pytest.raises(lethargy.TransformError):
-        Opt._transform(MockOpt(), "")
+        Opt.transform(MockOpt(), "")

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -10,15 +10,6 @@ import lethargy
 from lethargy.option import Option
 
 
-def all_args():
-    return ["-a", "b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
-
-
-@pytest.fixture
-def args():
-    return all_args()
-
-
 @pytest.mark.parametrize(
     "option, string",
     [
@@ -44,12 +35,22 @@ def test_string_form(option, string):
     assert str(option) == string
 
 
-def test_take_flag(args):
+def test_take_flag():
+    args = ["-a", "b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
+    assert "-a" in args
     assert Option("a").take_flag(args) is True
+    assert "-a" not in args
+
+
+def test_take_flag_when_flag_is_not_present():
+    args = ["-a", "b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
+    assert "-w" not in args
     assert Option("w").take_flag(args) is False
+    assert "-w" not in args
 
 
-def test_take_args_less_than_1_raises_err(args):
+def test_take_args_less_than_1_raises_err():
+    args = ["-a", "b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
     with pytest.raises(RuntimeError):
         Option("a").take_args(args)
 
@@ -59,12 +60,14 @@ def test_argc_cannot_be_set_below_0():
         Option("a", -1)
 
 
-def test_take_args_1_returns_single_value(args):
+def test_take_args_1_returns_single_value():
+    args = ["-a", "b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
     assert Option("a", 1).take_args(args) == "b"
     assert args == ["c", "-d", "e", "--fgh", "i", "j", "-xyz"]
 
 
-def test_take_args_2_or_more_returns_list(args):
+def test_take_args_2_or_more_returns_list():
+    args = ["-a", "b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
     assert Option("a", 2).take_args(args) == ["b", "c"]
     assert args == ["-d", "e", "--fgh", "i", "j", "-xyz"]
 
@@ -76,36 +79,45 @@ def test_take_args_valid_but_no_args_found_after_option():
     assert args == ["a", "b", "-c"]
 
 
-def test_take_args_greedy_returns_everything(args):
+def test_take_args_greedy_returns_everything():
+    args = ["-a", "b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
     expected = ["b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
     assert Option("a", ...).take_args(args) == expected
     assert args == []
 
 
 # opt not found, default none, raises false
-def test_take_args_not_found_1_arg_returns_single_none(args):
+def test_take_args_not_found_1_arg_returns_single_none():
+    args = ["-a", "b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
+    expected = args.copy()
     assert Option("w", 1).take_args(args) is None
-    assert args == all_args()
+    assert args == expected
 
 
-def test_take_args_not_found_2_or_more_returns_none_list(args):
+def test_take_args_not_found_2_or_more_returns_none_list():
+    args = ["-a", "b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
+    expected = args.copy()
     assert Option("w", 2).take_args(args) == [None, None]
-    assert args == all_args()
+    assert args == expected
 
 
-def test_take_args_not_found_greedy_returns_empty_list(args):
+def test_take_args_not_found_greedy_returns_empty_list():
+    args = ["-a", "b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
+    expected = args.copy()
     assert Option("w", ...).take_args(args) == []
-    assert args == all_args()
+    assert args == expected
 
 
 @pytest.mark.parametrize("amt", (2, ...))
-def test_take_args_not_found_return_value_is_falsy(args, amt):
+def test_take_args_not_found_return_value_is_falsy(amt):
+    args = ["-a", "b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
     assert not Option("w", amt).take_args(args)
 
 
 # opt not found, default not none, raises true
 @pytest.mark.parametrize("amt", (1, 2, ...))
-def test_take_args_not_found_raises_true_raises_missingoption(args, amt):
+def test_take_args_not_found_raises_true_raises_missingoption(amt):
+    args = ["-a", "b", "c", "-d", "e", "--fgh", "i", "j", "-xyz"]
     with pytest.raises(lethargy.MissingOption):
         assert Option("w", amt).take_args(args, required=True)
 

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -52,13 +52,13 @@ def test_take_flag(args):
 
 
 def test_take_args_less_than_1_raises_err(args):
-    with pytest.raises(lethargy.ArgsError):
+    with pytest.raises(RuntimeError):
         Opt("a").take_args(args)
-    with pytest.raises(lethargy.ArgsError):
-        x = Opt("a")
-        x._argc = -1
-        x.take_args(args)
-    assert args == all_args()
+
+
+def test_argc_cannot_be_set_below_0():
+    with pytest.raises(ValueError):
+        Opt("a", -1)
 
 
 def test_take_args_1_returns_single_value(args):
@@ -171,23 +171,23 @@ def test_converter_multiple_values(opt):
 def test_transform_calls_tfm_function_with_value():
     expected = []
 
-    class MockOpt:
+    class TfmOpt:
         def tfm(self, value):
             return value
 
-    assert Opt.transform(MockOpt(), expected) is expected
+    assert Opt.transform(TfmOpt(), expected) is expected
 
 
 def test_transform_raises_exception_with_correct_exception():
     class CustomException(Exception):
         pass
 
-    class MockOpt:
+    class TfmOpt:
         def tfm(self, _):
             raise CustomException
 
     with pytest.raises(CustomException):
-        Opt.transform(MockOpt(), "")
+        Opt.transform(TfmOpt(), "")
 
     with pytest.raises(lethargy.TransformError):
-        Opt.transform(MockOpt(), "")
+        Opt.transform(TfmOpt(), "")


### PR DESCRIPTION
3.0 removes the functions that 2.1 removed documentation for.

## Public API Changes

- Better documentation
- Changed name style of dynamic `TransformError` subclasses
- Removed `eprint`
- Removed `Opt`
- Removed `take_debug` and `take_verbose`
- Removed `print_if`

## Internal changes

- Renamed `Opt` to `Option`
- Removed `Option.takes`, merged functionality into `__init__`
- `Option.take_args` raises `RuntimeError` when the instance takes 0 arguments.
- Renamed `raises` keyword argument in `Option.take_args` to `required`
- Removed `Option.__eq__`
- Removed `Option.__copy__`
- Renamed class attributes (now `argc`, `tfm`, and `names`)
- Renamed `stab` utility to `tryposixname`
