### PR TITLE
Separate take_opt into 3 functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ verbose = lethargy.take_flag(['v', 'verbose'])
 
 # Accepts the option '--bytes <int>'. Show errors nicely if there's a problem.
 with lethargy.show_errors():
-    n_bytes = lethargy.take_some('bytes', 1, int) or 8
+    n_bytes = lethargy.take_args('bytes', 1, int) or 8
 
 
 # Expected options have been removed from lethargy.argv, now process manually.
@@ -108,7 +108,7 @@ Names are created automatically (POSIX style) if the given names start with a le
 
 ```python
 # -o|--output <value>
-output = lethargy.take_some(['o', 'output'], 1)
+output = lethargy.take_args(['o', 'output'], 1)
 
 print(output)
 ```
@@ -146,7 +146,7 @@ $ python example.py --ignore .git .vscode .DS_Store
 $ python example.py --ignore experiments
 experiments
 $ python example.py
-$ ▏
+$
 ```
 
 <table><tbody><tr><td>💡</td><td>
@@ -161,7 +161,7 @@ Variadic options are greedy and will take <b>every</b> argument that follows the
 
 ```python
 # --name <value> <value> <value>
-first, middle, last = lethargy.take_some('name', 3)
+first, middle, last = lethargy.take_args('name', 3)
 
 print(f'Hi, {first}!')
 ```
@@ -181,7 +181,7 @@ Hi, None!
 
 ```python
 # -h|--set-hours <value> <value>
-start, finish = lethargy.take_some(['set hours', 'h'], 2) or '9AM', '5PM'
+start, finish = lethargy.take_args(['set hours', 'h'], 2) or '9AM', '5PM'
 
 print(f'Employee now works {start} to {finish}')
 ```
@@ -205,7 +205,7 @@ You should use defaults unless your option explicitly sets <code>required=True</
 
 ```python
 # --date-ymd <int> <int> <int>
-y, m, d = lethargy.take_some('date ymd', 3, int) or 1970, 1, 1
+y, m, d = lethargy.take_args('date ymd', 3, int) or 1970, 1, 1
 
 from datetime import datetime
 date = datetime(y, m, d)
@@ -226,7 +226,7 @@ it has been 7500 days since 1999-10-09 00:00:00
 
 ```python
 with lethargy.show_errors():
-    x, y = lethargy.take_some(['p', 'pos'], 2, int) or 0, 0
+    x, y = lethargy.take_args(['p', 'pos'], 2, int) or 0, 0
 ```
 
 ```console

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ import lethargy
 
 # Accepts the option '--bytes <int>'. Show the error nicely if it goes wrong.
 with lethargy.show_errors():
-    n_bytes = lethargy.take_opt('bytes', 1, int) or 8
+    verbose = lethargy.take_flag(['verbose', 'v'])
+    n_bytes = lethargy.take_some('bytes', 1, int) or 8
 
 # Now the option and value have been removed from lethargy.argv
 with lethargy.expect(IndexError, reason='Missing required argument: [DIR]'):
@@ -50,7 +51,7 @@ This is both a tutorial and the documentation. All examples assume you've got `i
 
 ```python
 # --debug
-debug = lethargy.take_opt('debug')
+debug = lethargy.take_flag('debug')
 
 print(debug)
 ```
@@ -70,7 +71,7 @@ False
 
 ```python
 # -v|--verbose
-verbose = lethargy.take_opt(['v', 'verbose'])
+verbose = lethargy.take_flag(['v', 'verbose'])
 
 print(verbose)
 ```
@@ -90,11 +91,11 @@ Names are created automatically (POSIX style) if the given names start with a le
 
 ###### ARGUMENTS
 
-**Options can take arguments, too.** They can take any amount, and values are **always** space-separated.
+**Options can take arguments, too.** They can take any amount, and values are **always** separate (never `--xml=file.xml,sitemap.xml`).
 
 ```python
 # -o|--output <value>
-output = lethargy.take_opt(['o', 'output'], 1)
+output = lethargy.take_some(['o', 'output'], 1)
 
 print(output)
 ```
@@ -114,11 +115,11 @@ If there are fewer values than what the option takes, it'll raise <code>lethargy
 
 ###### GREEDINESS
 
-**Options can be variadic (greedy).** Use `...` instead of a number to take every value following the option.
+**Options can be variadic (greedy).** This takes every value following the option.
 
 ```python
 # -i|--ignore [value]...
-ignored = lethargy.take_opt(['i', 'ignore'], ...)
+ignored = lethargy.take_all(['i', 'ignore'])
 
 for pattern in ignored:
     print(pattern)
@@ -147,7 +148,7 @@ Variadic options are greedy and will take <b>every</b> argument that follows the
 
 ```python
 # --name <value> <value> <value>
-first, middle, last = lethargy.take_opt('name', 3)
+first, middle, last = lethargy.take_some('name', 3)
 
 print(f'Hi, {first}!')
 ```
@@ -167,7 +168,7 @@ Hi, None!
 
 ```python
 # -h|--set-hours <value> <value>
-start, finish = lethargy.take_opt(['set hours', 'h'], 2) or '9AM', '5PM'
+start, finish = lethargy.take_some(['set hours', 'h'], 2) or '9AM', '5PM'
 
 print(f'Employee now works {start} to {finish}')
 ```
@@ -191,7 +192,9 @@ You should use defaults unless your option explicitly sets <code>required=True</
 
 ```python
 # --date-ymd <int> <int> <int>
-y, m, d = lethargy.take_opt('date ymd', 3, int) or 1970, 1, 1
+y, m, d = lethargy.take_some('date ymd', 3, int) or 1970, 1, 1
+
+# 'take_all' also accepts a callable, by the way!
 
 from datetime import datetime
 date = datetime(y, m, d)
@@ -212,7 +215,7 @@ it has been 7500 days since 1999-10-09 00:00:00
 
 ```python
 with lethargy.show_errors():
-    x, y = lethargy.take_opt(['p', 'pos'], 2, int) or 0, 0
+    x, y = lethargy.take_some(['p', 'pos'], 2, int) or 0, 0
 ```
 
 ```console

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ Again, Lethargy is completely imperative and is **not** a framework. If you _are
 
 ## Installation
 
-You can use pip to install lethargy. It's tiny and only depends on the standard library.
+You can use pip to install lethargy. It's tiny and only depends on the standard library. [See the latest released version on PyPI][latest].
 
 ```console
 pip install lethargy
 ```
+
+[latest]: https://pypi.org/project/lethargy/
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Lethargy: Terse & tiny command-line option library
 
-**Lethargy was born out of frustration**. It gets out of your way as soon as possible to let you get on with the actual logic. No bullshit, no magic, no objects to understand, you just call a function.
+I write a lot of small scripts to automate the most boring parts of my job, and I frequently need to adapt these scripts to new requirements. To keep them maintainable, I **need** something less verbose than Click or Argparse, but more powerful than manually dealing with `sys.argv`. It needs to be imperative; I don't want to stick all the logic in an enormous function (losing a level of indentation), and I don't want `if __name__ == '__main__'`. I can deal with positional arguments by indexing a list, but damn, **options are annoying**.
 
-I write a lot of small scripts to get my job done faster, and manually working with options is a pain. Existing libraries are extremely verbose or just don't feel good to use. _Lethargy is designed to make writing scripts easier and faster, and to reduce effort needed to maintain them_.
+That's why I built lethargy! It gets out of your way as soon as possible to let you get on with the actual logic. No bullshit, no magic or arcane syntax, no docstring introspection, no objects to understand. _You just call a function_.
 
 <!-- Note that the spaces here are U+2000 (' ') EN QUAD -->
 <!--                 v                                  -->
 - **No boilerplate.** Headaches are directly proportional to lines of code.
 - **No bloat.** Small API surface area, very little to learn.
-- **No ambiguity.** Lethargy raises exceptions instead of getting your code into bad state.
+- **No ambiguity.** Lethargy makes absolutely no attempts to guess anything. Errors now > later.
 - **Clear errors.** Great error messages and context managers for dealing with them.
 - **Flexible.** You're not locked in to any styles or paradigms.
 
-Lethargy is completely imperative and is **not** a framework. If you _are_ building a complete CLI or want automatic help commands, you're better off using **[Click]** — a fantastic, declarative CLI framework.
+Again, Lethargy is completely imperative and is **not** a framework. If you _are_ building a complete CLI or want automatic help commands, you're better off using **[Click]** — a fantastic, declarative CLI framework.
 
 [Click]: https://click.palletsprojects.com/en/7.x/
 

--- a/README.md
+++ b/README.md
@@ -29,21 +29,34 @@ pip install lethargy
 ```python
 import lethargy
 
-# Accepts the option '--bytes <int>'. Show the error nicely if it goes wrong.
+# False, unless '-v|--verbose' is given.
+verbose = lethargy.take_flag(['v', 'verbose'])
+
+
+# Accepts the option '--bytes <int>'. Show errors nicely if there's a problem.
 with lethargy.show_errors():
-    verbose = lethargy.take_flag(['verbose', 'v'])
     n_bytes = lethargy.take_some('bytes', 1, int) or 8
 
-# Now the option and value have been removed from lethargy.argv
+
+# Expected options have been removed from lethargy.argv, now process manually.
 with lethargy.expect(IndexError, reason='Missing required argument: [DIR]'):
     directory = lethargy.argv[1]
+
+
+if verbose:
+    print(f'[v] Checking first {n_bytes} of files in {repr(directory)}...')
 
 ...
 ```
 
+```console
+$ python example.py -v Documents/ --bytes 4
+[v] Checking first 4 bytes of files in 'Documents'...
+```
+
 ## Getting Started
 
-This is both a tutorial and the documentation. All examples assume you've got `import lethargy` at the top.
+This is both a tutorial and the documentation. All examples assume you've got `import lethargy` at the top and that the file is called 'example\.py'.
 
 ###### FLAGS
 
@@ -91,7 +104,7 @@ Names are created automatically (POSIX style) if the given names start with a le
 
 ###### ARGUMENTS
 
-**Options can take arguments, too.** They can take any amount, and values are **always** separate (never `--xml=file.xml,sitemap.xml`).
+**Options can take arguments, too.** They can take any positive, non-zero amount, and distinct values are _always_ separate.
 
 ```python
 # -o|--output <value>
@@ -188,13 +201,11 @@ You should use defaults unless your option explicitly sets <code>required=True</
 
 ###### TYPES & CONVERSION
 
-**Convert your option's values.** Use a function or type as the final argument. Defaults aren't converted.
+**Convert your option's values.** Options that take arguments can use a function or type as the final argument.
 
 ```python
 # --date-ymd <int> <int> <int>
 y, m, d = lethargy.take_some('date ymd', 3, int) or 1970, 1, 1
-
-# 'take_all' also accepts a callable, by the way!
 
 from datetime import datetime
 date = datetime(y, m, d)

--- a/lethargy/__init__.py
+++ b/lethargy/__init__.py
@@ -6,7 +6,7 @@ __all__ = (
     # Options & arguments
     # -------------------
     "take_flag",
-    "take_some",
+    "take_args",
     "take_all",
     "argv",
 
@@ -26,5 +26,5 @@ __all__ = (
 # fmt: on
 
 from lethargy.errors import ArgsError, MissingOption, OptionError, TransformError
-from lethargy.options import take_flag, take_some, take_all
+from lethargy.options import take_flag, take_args, take_all
 from lethargy.util import argv, expect, fail, show_errors

--- a/lethargy/__init__.py
+++ b/lethargy/__init__.py
@@ -5,7 +5,9 @@ __version__ = "3.1.0"
 __all__ = (
     # Options & arguments
     # -------------------
-    "take_opt",
+    "take_flag",
+    "take_some",
+    "take_all",
     "argv",
 
     # Error handling
@@ -24,5 +26,5 @@ __all__ = (
 # fmt: on
 
 from lethargy.errors import ArgsError, MissingOption, OptionError, TransformError
-from lethargy.options import take_opt
+from lethargy.options import take_flag, take_some, take_all
 from lethargy.util import argv, expect, fail, show_errors

--- a/lethargy/__init__.py
+++ b/lethargy/__init__.py
@@ -1,7 +1,7 @@
 """Declarative, dynamic option parsing."""
 
 # fmt: off
-__version__ = "3.1.0"
+__version__ = "4.0.0-dev"
 __all__ = (
     # Options & arguments
     # -------------------

--- a/lethargy/options.py
+++ b/lethargy/options.py
@@ -120,7 +120,8 @@ class Variadic(Named, Transforming):
         """Transform each argument found."""
         return [self.transform(arg) for arg in args[1:]]
 
-    def missing(self):
+    @staticmethod
+    def missing():
         """Get an empty list."""
         return []
 
@@ -138,11 +139,13 @@ class Flag(Named):
     def __str__(self):
         return self.prettynames()
 
-    def found(self, _):
+    @staticmethod
+    def found(_):
         """Literal `True`"""
         return True
 
-    def missing(self):
+    @staticmethod
+    def missing():
         """Literal `False`"""
         return False
 

--- a/lethargy/options.py
+++ b/lethargy/options.py
@@ -2,7 +2,7 @@
 
 from lethargy.errors import ArgsError
 from lethargy.mixins import Named, Requirable, Transforming
-from lethargy.util import argv, falsylist, identity, names_from
+from lethargy.util import argv, falsylist, names_from, identity as itself
 
 
 def take_flag(name, *, args=argv, mut=True):
@@ -11,8 +11,8 @@ def take_flag(name, *, args=argv, mut=True):
     return take(option, args, mut=mut)
 
 
-def take_some(name, number, each=identity, *, args=argv, mut=True, required=False):
-    """Take an option and its arguments from a list of arguments."""
+def take_some(name, number, each=itself, *, args=argv, mut=True, required=False):
+    """Take an option and arguments belonging to it from a list of arguments."""
     if number < 1:
         msg = f"The number of params ({number}) must be greater than 0."
         raise ValueError(msg)
@@ -21,7 +21,7 @@ def take_some(name, number, each=identity, *, args=argv, mut=True, required=Fals
     return take(option, args, mut=mut)
 
 
-def take_all(name, each=identity, *, args=argv, mut=True):
+def take_all(name, each=itself, *, args=argv, mut=True):
     """Take an option and all following arguments from a list of arguments."""
     option = Variadic(names_from(name), each)
     return take(option, args, mut=mut)

--- a/lethargy/options.py
+++ b/lethargy/options.py
@@ -11,7 +11,7 @@ def take_flag(name, *, args=argv, mut=True):
     return take(option, args, mut=mut)
 
 
-def take_some(name, number, each=itself, *, args=argv, mut=True, required=False):
+def take_args(name, number, each=itself, *, args=argv, mut=True, required=False):
     """Take an option and arguments belonging to it from a list of arguments."""
     if number < 1:
         msg = f"The number of params ({number}) must be greater than 0."

--- a/lethargy/util.py
+++ b/lethargy/util.py
@@ -31,7 +31,7 @@ def try_name(text):
 
     # Assume it's been pre-formatted if it starts with something that's not
     # a letter or number.
-    if not stripped[:1].isalnum():
+    if not stripped[0].isalnum():
         return stripped
 
     name = "-".join(stripped.split())

--- a/lethargy/util.py
+++ b/lethargy/util.py
@@ -19,7 +19,7 @@ def names_from(name):
 
     names = name if not isinstance(name, str) else [name]
 
-    return frozenset(map(try_name, names))
+    return {try_name(nm) for nm in names}
 
 
 def try_name(text):

--- a/lethargy/util.py
+++ b/lethargy/util.py
@@ -2,7 +2,6 @@
 
 import sys
 from contextlib import contextmanager
-from collections.abc import Collection
 
 from lethargy.errors import OptionError, TransformError
 
@@ -13,12 +12,17 @@ argv = sys.argv.copy()
 falsylist = type("falsylist", (list,), {"__bool__": lambda _: False})
 
 
-def into_list(o):
-    """Put `o` in a list, if it's not a collection."""
-    return [o] if isinstance(o, str) or not isinstance(o, Collection) else o
+def names_from(name):
+    """Create a frozenset of potentially POSIX-like names from a string or sequence."""
+    if not name:
+        raise ValueError("Options must have at least one name.")
+
+    names = name if not isinstance(name, str) else [name]
+
+    return frozenset(map(try_name, names))
 
 
-def tryname(text):
+def try_name(text):
     """Try to make a loosely POSIX-style name."""
     stripped = str(text).strip()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lethargy"
-version = "3.1.0"
+version = "4.0.0-dev"
 description = "A minimal library to make your option-parsing easier."
 license = "MIT"
 repository = "https://github.com/SeparateRecords/lethargy"

--- a/tests/options/test_explicit.py
+++ b/tests/options/test_explicit.py
@@ -11,6 +11,8 @@ from lethargy.options import Explicit as Ex
 from lethargy.util import identity
 from lethargy.errors import MissingOption, ArgsError
 
+parametrize = pytest.mark.parametrize
+
 
 def test_init():
     a, b, c, d = object(), object(), object(), object()
@@ -21,13 +23,13 @@ def test_init():
     assert e.required is d
 
 
-@pytest.mark.parametrize("required", (True, False))
+@parametrize("required", (True, False))
 def test_str(required):
     e = Ex(["-e", "--example", "-x"], 2, float, required)
     assert str(e) == "-e|-x|--example <float> <float>"
 
 
-@pytest.mark.parametrize("required", (True, False))
+@parametrize("required", (True, False))
 def test_span_returns_correct_indices(required):
     number = 3
     thething = "b"
@@ -47,7 +49,7 @@ def test_span_raises_indexerror_if_not_required_and_not_found():
         Ex("w", 1, identity, False).span("xyz")
 
 
-@pytest.mark.parametrize("required", (True, False))
+@parametrize("required", (True, False))
 def test_span_with_fewer_arguments_than_expected_raises_argserror(required):
     with pytest.raises(ArgsError):
         Ex("x", 3, identity, required).span("xyz")
@@ -73,13 +75,13 @@ def test_missing_returns_falsy_list_of_none_if_number_is_not_1():
     assert not missing
 
 
-@pytest.mark.parametrize("required", (True, False))
+@parametrize("required", (True, False))
 def test_found_returns_index_1_alone_if_it_only_takes_1_argument(required):
     # All it cares about should be args[1], in this case, "c"
     assert Ex("b", 1, identity, required).found("bcdef") == "c"
 
 
-@pytest.mark.parametrize("required", (True, False))
+@parametrize("required", (True, False))
 def test_found_returns_list_if_number_is_not_1(required):
     # It shouldn't actually care how many arguments it's supposed to
     # take, found just transforms the arguments it... found, whatever
@@ -87,8 +89,8 @@ def test_found_returns_list_if_number_is_not_1(required):
     assert Ex("b", -1, identity, required).found("bcdef") == list("cdef")
 
 
-@pytest.mark.parametrize("required", (True, False))
-@pytest.mark.parametrize("number, expected", [(1, [1]), (3, [1, 2, 3])])
+@parametrize("required", (True, False))
+@parametrize("number, expected", [(1, [1]), (3, [1, 2, 3])])
 def test_found_calls_transform_on_arguments(required, number, expected):
     accumulated = []
 

--- a/tests/options/test_flag.py
+++ b/tests/options/test_flag.py
@@ -19,11 +19,11 @@ def test_str_is_prettynames():
 
 
 def test_found_is_always_true():
-    assert Flag.found(None, None) is True
+    assert Flag.found(None) is True
 
 
 def test_missing_is_always_false():
-    assert Flag.missing(None) is False
+    assert Flag.missing() is False
 
 
 def test_span_raises_indexerror_if_not_in_args():

--- a/tests/options/test_variadic.py
+++ b/tests/options/test_variadic.py
@@ -23,7 +23,7 @@ def test_str():
 
 
 def test_missing_is_always_empty_list():
-    assert Var.missing(None) == []
+    assert Var.missing() == []
 
 
 def test_found_transforms_each_argument_after_first():

--- a/tests/take/test_take.py
+++ b/tests/take/test_take.py
@@ -9,8 +9,10 @@ import pytest
 
 from lethargy.options import take
 
+parametrize = pytest.mark.parametrize
 
-@pytest.mark.parametrize("mut", (True, False))
+
+@parametrize("mut", (True, False))
 def test_missing_called_if_span_raises_indexerror(mut):
     class FunctionCalled(Exception):
         pass
@@ -26,7 +28,7 @@ def test_missing_called_if_span_raises_indexerror(mut):
         take(Fake(), None, mut=mut)
 
 
-@pytest.mark.parametrize("mut", (True, False))
+@parametrize("mut", (True, False))
 def test_missing_can_raise_other_exceptions(mut):
     class CustomException(Exception):
         pass
@@ -39,7 +41,7 @@ def test_missing_can_raise_other_exceptions(mut):
         take(Fake(), None, mut=mut)
 
 
-@pytest.mark.parametrize("mut", (True, False))
+@parametrize("mut", (True, False))
 def test_found_is_called_with_items_from_span_if_span_does_not_raise_indexerror(mut):
     class FunctionCalled(Exception):
         pass
@@ -61,9 +63,7 @@ def test_found_is_called_with_items_from_span_if_span_does_not_raise_indexerror(
         assert str(f) == expecting
 
 
-@pytest.mark.parametrize(
-    "mut, expected", [(True, [0, 1, 4, 5]), (False, [0, 1, 2, 3, 4, 5])]
-)
+@parametrize("mut, expected", [(True, [0, 1, 4, 5]), (False, [0, 1, 2, 3, 4, 5])])
 def test_only_removes_items_from_span_if_mut_is_true(mut, expected):
     class Fake:
         def span(self, _):
@@ -94,7 +94,7 @@ def test_span_can_return_none_tuple():
         assert str(f) == "help me"
 
 
-@pytest.mark.parametrize("mut", (True, False))
+@parametrize("mut", (True, False))
 def test_take_returns_result_of_found(mut):
     class Fake:
         def span(self, _):

--- a/tests/take/test_take_all.py
+++ b/tests/take/test_take_all.py
@@ -1,3 +1,10 @@
+# Keep on separate lines for better diff and readability ~
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=missing-module-docstring
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+
 import pytest
 
 from lethargy import take_all

--- a/tests/take/test_take_all.py
+++ b/tests/take/test_take_all.py
@@ -1,0 +1,43 @@
+import pytest
+
+from lethargy import take_all
+
+parametrize = pytest.mark.parametrize
+x = str.split
+
+
+def test_takes_all_following_arguments():
+    args = x("a b -x c d e")
+    assert take_all("x", args=args) == x("c d e")
+    assert args == x("a b")
+
+
+def test_no_mut_takes_all_following_arguments():
+    args = x("a b -x c d e")
+    assert take_all("x", args=args, mut=False) == x("c d e")
+    assert args == x("a b -x c d e")
+
+
+# ---
+
+
+def test_takes_all_following_arguments_and_calls_callable():
+    args = x("2 1 -x 1 2 3")
+    assert take_all("x", int, args=args) == [1, 2, 3]
+    assert args == x("2 1")
+
+
+def test_no_mut_takes_all_following_arguments_and_calls_callable():
+    args = x("2 1 -x 1 2 3")
+    assert take_all("x", int, args=args, mut=False) == [1, 2, 3]
+    assert args == x("2 1 -x 1 2 3")
+
+
+# ---
+
+
+@pytest.mark.parametrize("mut", (True, False))
+def test_no_args_found_is_empty_list(mut):
+    args = x("# # a #")
+    assert take_all("This shouldn't be found!", args=args, mut=mut) == []
+    assert args == x("# # a #")

--- a/tests/take/test_take_args.py
+++ b/tests/take/test_take_args.py
@@ -7,7 +7,7 @@
 
 import pytest
 
-from lethargy import take_some, ArgsError, MissingOption
+from lethargy import take_args, ArgsError, MissingOption
 
 x = str.split
 
@@ -15,13 +15,13 @@ x = str.split
 @pytest.mark.parametrize("name", ("x", ["not found", "x"]))
 def test_take_one_is_single_value(name):
     args = x("# -x a #")
-    assert take_some(name, 1, args=args) == "a"
+    assert take_args(name, 1, args=args) == "a"
     assert args == x("# #")
 
 
 def test_no_mut_take_one_is_single_value():
     args = x("# -x a #")
-    assert take_some("x", 1, args=args, mut=False) == "a"
+    assert take_args("x", 1, args=args, mut=False) == "a"
     assert args == x("# -x a #")
 
 
@@ -30,13 +30,13 @@ def test_no_mut_take_one_is_single_value():
 
 def test_take_one_with_callable_is_single_value():
     args = x("# -x 1 #")
-    assert take_some("x", 1, int, args=args) == 1
+    assert take_args("x", 1, int, args=args) == 1
     assert args == x("# #")
 
 
 def test_no_mut_take_one_with_callable_is_single_value():
     args = x("# -x 1 #")
-    assert take_some("x", 1, int, args=args, mut=False) == 1
+    assert take_args("x", 1, int, args=args, mut=False) == 1
     assert args == x("# -x 1 #")
 
 
@@ -45,13 +45,13 @@ def test_no_mut_take_one_with_callable_is_single_value():
 
 def test_take_one_with_callable_is_single_value():
     args = x("# -x 1 #")
-    assert take_some("x", 1, int, args=args) == 1
+    assert take_args("x", 1, int, args=args) == 1
     assert args == x("# #")
 
 
 def test_no_mut_take_one_with_callable_is_single_value():
     args = x("# -x 1 #")
-    assert take_some("x", 1, int, args=args, mut=False) == 1
+    assert take_args("x", 1, int, args=args, mut=False) == 1
     assert args == x("# -x 1 #")
 
 
@@ -60,13 +60,13 @@ def test_no_mut_take_one_with_callable_is_single_value():
 
 def test_take_two_is_list():
     args = x("# -x a b #")
-    assert take_some("x", 2, args=args) == ["a", "b"]
+    assert take_args("x", 2, args=args) == ["a", "b"]
     assert args == x("# #")
 
 
 def test_no_mut_take_two_is_list():
     args = x("# -x a b #")
-    assert take_some("x", 2, args=args, mut=False) == ["a", "b"]
+    assert take_args("x", 2, args=args, mut=False) == ["a", "b"]
     assert args == x("# -x a b #")
 
 
@@ -75,13 +75,13 @@ def test_no_mut_take_two_is_list():
 
 def test_take_two_with_callable_is_list():
     args = x("# -x 1 2 #")
-    assert take_some("x", 2, int, args=args) == [1, 2]
+    assert take_args("x", 2, int, args=args) == [1, 2]
     assert args == x("# #")
 
 
 def test_no_mut_take_two_with_callable_is_list():
     args = x("# -x 1 2 #")
-    assert take_some("x", 2, int, args=args) == [1, 2]
+    assert take_args("x", 2, int, args=args) == [1, 2]
     assert args == x("# #")
 
 
@@ -91,14 +91,14 @@ def test_no_mut_take_two_with_callable_is_list():
 def test_using_number_under_one_raises_error():
     args = x("# -x a b #")
     with pytest.raises(ValueError):
-        take_some("x", 0, args=args)
+        take_args("x", 0, args=args)
     assert args == x("# -x a b #")
 
 
 def test_no_mut_using_number_under_one_raises_error():
     args = x("# -x a b #")
     with pytest.raises(ValueError):
-        take_some("x", 0, args=args, mut=False)
+        take_args("x", 0, args=args, mut=False)
     assert args == x("# -x a b #")
 
 
@@ -108,14 +108,14 @@ def test_no_mut_using_number_under_one_raises_error():
 def test_must_have_at_least_n_arguments():
     args = x("# -x")
     with pytest.raises(ArgsError):
-        take_some("x", 1, args=args)
+        take_args("x", 1, args=args)
     assert args == x("# -x")
 
 
 def test_no_mut_must_have_at_least_n_arguments():
     args = x("# -x")
     with pytest.raises(ArgsError):
-        take_some("x", 1, args=args, mut=False)
+        take_args("x", 1, args=args, mut=False)
     assert args == x("# -x")
 
 
@@ -125,14 +125,14 @@ def test_no_mut_must_have_at_least_n_arguments():
 def test_must_have_at_least_n_arguments_with_callable():
     args = x("# -x")
     with pytest.raises(ArgsError):
-        take_some("x", 1, int, args=args)
+        take_args("x", 1, int, args=args)
     assert args == x("# -x")
 
 
 def test_no_mut_must_have_at_least_n_arguments_with_callable():
     args = x("# -x")
     with pytest.raises(ArgsError):
-        take_some("x", 1, int, args=args, mut=False)
+        take_args("x", 1, int, args=args, mut=False)
     assert args == x("# -x")
 
 
@@ -142,12 +142,12 @@ def test_no_mut_must_have_at_least_n_arguments_with_callable():
 def test_required_argument_must_be_present():
     args = x("# # #")
     with pytest.raises(MissingOption):
-        take_some("x", 1, required=True, args=args)
+        take_args("x", 1, required=True, args=args)
     assert args == x("# # #")
 
 
 def test_required_argument_must_be_present():
     args = x("# # #")
     with pytest.raises(MissingOption):
-        take_some("x", 1, required=True, args=args, mut=False)
+        take_args("x", 1, required=True, args=args, mut=False)
     assert args == x("# # #")

--- a/tests/take/test_take_flag.py
+++ b/tests/take/test_take_flag.py
@@ -1,0 +1,24 @@
+import pytest
+
+from lethargy import take_flag
+
+x = str.split
+
+
+def test_true_if_in_args():
+    args = x("# -x #")
+    assert take_flag("x", args=args) is True
+    assert args == x("# #")
+
+
+def test_no_mut_true_if_in_args():
+    args = x("# -x #")
+    assert take_flag("x", args=args, mut=False) is True
+    assert args == x("# -x #")
+
+
+@pytest.mark.parametrize("mut", (True, False))
+def test_false_if_not_in_args(mut):
+    args = x("# #")
+    assert take_flag("x", args=args, mut=mut) is False
+    assert args == x("# #")

--- a/tests/take/test_take_flag.py
+++ b/tests/take/test_take_flag.py
@@ -1,3 +1,10 @@
+# Keep on separate lines for better diff and readability ~
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=missing-module-docstring
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+
 import pytest
 
 from lethargy import take_flag

--- a/tests/take/test_take_some.py
+++ b/tests/take/test_take_some.py
@@ -1,0 +1,146 @@
+import pytest
+
+from lethargy import take_some, ArgsError, MissingOption
+
+x = str.split
+
+
+@pytest.mark.parametrize("name", ("x", ["not found", "x"]))
+def test_take_one_is_single_value(name):
+    args = x("# -x a #")
+    assert take_some(name, 1, args=args) == "a"
+    assert args == x("# #")
+
+
+def test_no_mut_take_one_is_single_value():
+    args = x("# -x a #")
+    assert take_some("x", 1, args=args, mut=False) == "a"
+    assert args == x("# -x a #")
+
+
+# ---
+
+
+def test_take_one_with_callable_is_single_value():
+    args = x("# -x 1 #")
+    assert take_some("x", 1, int, args=args) == 1
+    assert args == x("# #")
+
+
+def test_no_mut_take_one_with_callable_is_single_value():
+    args = x("# -x 1 #")
+    assert take_some("x", 1, int, args=args, mut=False) == 1
+    assert args == x("# -x 1 #")
+
+
+# ---
+
+
+def test_take_one_with_callable_is_single_value():
+    args = x("# -x 1 #")
+    assert take_some("x", 1, int, args=args) == 1
+    assert args == x("# #")
+
+
+def test_no_mut_take_one_with_callable_is_single_value():
+    args = x("# -x 1 #")
+    assert take_some("x", 1, int, args=args, mut=False) == 1
+    assert args == x("# -x 1 #")
+
+
+# ---
+
+
+def test_take_two_is_list():
+    args = x("# -x a b #")
+    assert take_some("x", 2, args=args) == ["a", "b"]
+    assert args == x("# #")
+
+
+def test_no_mut_take_two_is_list():
+    args = x("# -x a b #")
+    assert take_some("x", 2, args=args, mut=False) == ["a", "b"]
+    assert args == x("# -x a b #")
+
+
+# ---
+
+
+def test_take_two_with_callable_is_list():
+    args = x("# -x 1 2 #")
+    assert take_some("x", 2, int, args=args) == [1, 2]
+    assert args == x("# #")
+
+
+def test_no_mut_take_two_with_callable_is_list():
+    args = x("# -x 1 2 #")
+    assert take_some("x", 2, int, args=args) == [1, 2]
+    assert args == x("# #")
+
+
+# ---
+
+
+def test_using_number_under_one_raises_error():
+    args = x("# -x a b #")
+    with pytest.raises(ValueError):
+        take_some("x", 0, args=args)
+    assert args == x("# -x a b #")
+
+
+def test_no_mut_using_number_under_one_raises_error():
+    args = x("# -x a b #")
+    with pytest.raises(ValueError):
+        take_some("x", 0, args=args, mut=False)
+    assert args == x("# -x a b #")
+
+
+# ---
+
+
+def test_must_have_at_least_n_arguments():
+    args = x("# -x")
+    with pytest.raises(ArgsError):
+        take_some("x", 1, args=args)
+    assert args == x("# -x")
+
+
+def test_no_mut_must_have_at_least_n_arguments():
+    args = x("# -x")
+    with pytest.raises(ArgsError):
+        take_some("x", 1, args=args, mut=False)
+    assert args == x("# -x")
+
+
+# ---
+
+
+def test_must_have_at_least_n_arguments_with_callable():
+    args = x("# -x")
+    with pytest.raises(ArgsError):
+        take_some("x", 1, int, args=args)
+    assert args == x("# -x")
+
+
+def test_no_mut_must_have_at_least_n_arguments_with_callable():
+    args = x("# -x")
+    with pytest.raises(ArgsError):
+        take_some("x", 1, int, args=args, mut=False)
+    assert args == x("# -x")
+
+
+# ---
+
+
+def test_required_argument_must_be_present():
+    args = x("# # #")
+    with pytest.raises(MissingOption):
+        take_some("x", 1, required=True, args=args)
+    assert args == x("# # #")
+
+
+def test_required_argument_must_be_present():
+    args = x("# # #")
+    with pytest.raises(MissingOption):
+        take_some("x", 1, required=True, args=args, mut=False)
+    assert args == x("# # #")

--- a/tests/take/test_take_some.py
+++ b/tests/take/test_take_some.py
@@ -1,3 +1,10 @@
+# Keep on separate lines for better diff and readability ~
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=missing-module-docstring
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+
 import pytest
 
 from lethargy import take_some, ArgsError, MissingOption

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,22 +89,16 @@ def test_identity():
     assert util.identity(o) is o
 
 
-def test_into_list():
-    assert util.into_list("test") == ["test"]
-    assert util.into_list(["test"]) == ["test"]
-    assert util.into_list(("test",)) == ("test",)
+def test_try_name():
+    assert util.try_name("test") == "--test"
+    assert util.try_name("t") == "-t"
+    assert util.try_name("1") == "-1"
+    assert util.try_name("-1") == "-1"
+    assert util.try_name("-t") == "-t"
+    assert util.try_name("-test") == "-test"
+    assert util.try_name("+1") == "+1"
 
 
-def test_tryname():
-    assert util.tryname("test") == "--test"
-    assert util.tryname("t") == "-t"
-    assert util.tryname("1") == "-1"
-    assert util.tryname("-1") == "-1"
-    assert util.tryname("-t") == "-t"
-    assert util.tryname("-test") == "-test"
-    assert util.tryname("+1") == "+1"
-
-
-def test_tryname_fails_on_empty_name():
+def test_try_name_fails_on_empty_name():
     with pytest.raises(ValueError):
-        util.tryname("")
+        util.try_name("")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,41 +12,44 @@ import pytest
 import lethargy
 from lethargy import util
 
+parametrize = pytest.mark.parametrize
+
 
 def test_argv_is_not_sys_argv():
-    assert lethargy.argv is not sys.argv
+    assert util.argv is not sys.argv
 
 
 def test_argv_equals_sys_argv():
-    assert lethargy.argv == sys.argv
+    assert util.argv == sys.argv
 
 
 def test_falsylist_is_list():
-    assert isinstance(lethargy.util.falsylist(), list)
+    assert isinstance(util.falsylist(), list)
+    assert isinstance(util.falsylist, type)
 
 
 def test_falsylist_is_always_falsy():
     # falsylist should not require itself to return false -- it's always falsy.
-    assert lethargy.util.falsylist.__bool__(None) is False
+    assert util.falsylist.__bool__(None) is False
 
 
-@pytest.mark.parametrize("message", (None, "Message"))
+@parametrize("message", (None, "Message"))
 def test_fail_exits(message):
     with pytest.raises(SystemExit):
-        lethargy.fail(message)
+        util.fail(message)
 
 
-@pytest.mark.parametrize("message", (None, "Message"))
+@parametrize("message", (None, "Message"))
 def test_fail_exits_with_code_1(message):
     try:
-        lethargy.fail(message)
-    except SystemExit as e:
-        assert e.code == 1
+        util.fail(message)
+    except SystemExit as error:
+        assert error.code == 1
 
 
 def test_fail_prints_message_to_stderr(capsys):
     with contextlib.suppress(SystemExit):
-        lethargy.fail("Message!")
+        util.fail("Message!")
     out, err = capsys.readouterr()
     assert err == "Message!\n"
     assert out == ""
@@ -54,15 +57,15 @@ def test_fail_prints_message_to_stderr(capsys):
 
 def test_fail_without_message_prints_nothing(capsys):
     with contextlib.suppress(SystemExit):
-        lethargy.fail()
+        util.fail()
     out, err = capsys.readouterr()
     assert out == err == ""
 
 
-@pytest.mark.parametrize("current_err", (ValueError, IndexError))
+@parametrize("current_err", (ValueError, IndexError))
 def test_expect(capsys, current_err):
     with contextlib.suppress(SystemExit):
-        with lethargy.expect(ValueError, IndexError):
+        with util.expect(ValueError, IndexError):
             raise current_err("Uh oh!")
     _, err = capsys.readouterr()
     assert err == "Uh oh!\n"
@@ -70,7 +73,7 @@ def test_expect(capsys, current_err):
 
 def test_expect_custom_message_overrides_exception_message(capsys):
     with contextlib.suppress(SystemExit):
-        with lethargy.expect(RuntimeError, reason="yikes"):
+        with util.expect(RuntimeError, reason="yikes"):
             raise RuntimeError("Uh oh!")
     _, err = capsys.readouterr()
     assert err == "yikes\n"
@@ -78,8 +81,8 @@ def test_expect_custom_message_overrides_exception_message(capsys):
 
 def test_show_errors(capsys):
     with contextlib.suppress(SystemExit):
-        with lethargy.show_errors():
-            raise lethargy.OptionError("damn")
+        with util.show_errors():
+            raise util.OptionError("damn")
     _, err = capsys.readouterr()
     assert err == "damn\n"
 
@@ -102,3 +105,18 @@ def test_try_name():
 def test_try_name_fails_on_empty_name():
     with pytest.raises(ValueError):
         util.try_name("")
+
+
+def test_names_from():
+    assert util.names_from("x") == {"-x"}
+    assert util.names_from(["x"]) == {"-x"}
+    assert util.names_from(["x", "y"]) == {"-x", "-y"}
+
+    with pytest.raises(ValueError):
+        util.names_from("")
+
+    with pytest.raises(ValueError):
+        util.names_from([])
+
+    with pytest.raises(ValueError):
+        util.names_from([""])


### PR DESCRIPTION
This PR removes `take_opt` and replaces it with 3 distinct functions.

* `take_all`: Take all following arguments (equivalent of `take_opt("xyz", ...)`)
* `take_args`: Take N arguments (equivalent of `take_opt("xyz", <int>)`)
* `take_flag`: Get True or False based on option presence (same as `take_opt("xyz")`)

## Rationale

`take_opt` became what I swore to destroy. It was 1 function with effectively 3 different signatures, which was complicated and bad.

**This change is breaking and can only be included in version 4.0.**

## Plans

In addition to this, argument comma-separation is planned for 4.0, which is also technically breaking because values that would be missed before can now be recognised as options, and allows variadic options to take a limited amount.